### PR TITLE
Restore audio in creation previews

### DIFF
--- a/lib/features/create/presentation/create_event_screen.dart
+++ b/lib/features/create/presentation/create_event_screen.dart
@@ -360,7 +360,6 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
           if (!controller.value.isPlaying) {
             controller
               ..setLooping(true)
-              ..setVolume(0)
               ..play();
           }
           return FittedBox(
@@ -674,7 +673,6 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
           });
           controller
             ..setLooping(true)
-            ..setVolume(0)
             ..play();
         });
       });

--- a/lib/features/create/presentation/media_composer_screen.dart
+++ b/lib/features/create/presentation/media_composer_screen.dart
@@ -83,8 +83,7 @@ class _MediaComposerScreenState extends State<MediaComposerScreen> {
 
   void _initializeVideo() {
     final controller = VideoPlayerController.file(File(widget.mediaPath))
-      ..setLooping(true)
-      ..setVolume(0);
+      ..setLooping(true);
     _videoInitialization = controller.initialize().then((_) {
       if (mounted) {
         setState(() {

--- a/lib/features/create/presentation/media_picker_screen.dart
+++ b/lib/features/create/presentation/media_picker_screen.dart
@@ -214,8 +214,7 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
     VideoPlayerController? controller;
     if (asset.type == AssetType.video) {
       controller = VideoPlayerController.file(file)
-        ..setLooping(true)
-        ..setVolume(0);
+        ..setLooping(true);
       try {
         await controller.initialize();
         await controller.play();


### PR DESCRIPTION
## Summary
- allow media picker preview videos to play with their original audio instead of forcing mute
- let the media composer video preview initialize without muting the track
- ensure create event video previews no longer silence audio so users hear clips while editing

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a8f045b08328944da2a977cd9e80