### PR TITLE
Add video proxy pipeline for media previews

### DIFF
--- a/lib/features/create/domain/video_proxy_service.dart
+++ b/lib/features/create/domain/video_proxy_service.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:video_compress/video_compress.dart';
+
+class VideoProxyResult {
+  VideoProxyResult({required this.originalPath, required this.proxyPath});
+
+  final String originalPath;
+  final String proxyPath;
+}
+
+class VideoProxyService {
+  VideoProxyService._() {
+    VideoCompress.setLogLevel(0);
+  }
+
+  static final VideoProxyService instance = VideoProxyService._();
+
+  static const int _maxSafeDimension = 1080;
+  static const int _maxSafeBytes = 60 * 1024 * 1024; // 60 MB
+
+  final Map<String, VideoProxyResult> _cache = <String, VideoProxyResult>{};
+  final Map<String, _ProxyJob> _jobs = <String, _ProxyJob>{};
+
+  Future<bool> shouldTranscode({
+    required String path,
+    int? width,
+    int? height,
+    int? fileLengthBytes,
+  }) async {
+    int? resolvedSize = fileLengthBytes;
+    if (resolvedSize == null) {
+      try {
+        resolvedSize = await File(path).length();
+      } catch (_) {
+        resolvedSize = null;
+      }
+    }
+    if (resolvedSize != null && resolvedSize > _maxSafeBytes) {
+      return true;
+    }
+
+    final resolvedWidth = width;
+    final resolvedHeight = height;
+    if (resolvedWidth != null && resolvedHeight != null) {
+      final maxDimension = math.max(resolvedWidth, resolvedHeight);
+      if (maxDimension > _maxSafeDimension) {
+        return true;
+      }
+    }
+
+    if (resolvedWidth != null && resolvedHeight != null) {
+      return false;
+    }
+
+    MediaInfo info;
+    try {
+      info = await VideoCompress.getMediaInfo(path);
+    } catch (_) {
+      return false;
+    }
+    final infoWidth = info.width;
+    final infoHeight = info.height;
+    if (info.filesize != null && info.filesize! > _maxSafeBytes) {
+      return true;
+    }
+    if (infoWidth != null && infoHeight != null) {
+      final maxDimension = math.max(infoWidth, infoHeight);
+      if (maxDimension > _maxSafeDimension) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  VideoProxyResult? getCachedProxy(String originalPath) {
+    return _cache[originalPath];
+  }
+
+  Future<VideoProxyResult> ensureProxy(
+    String originalPath, {
+    void Function(double progress)? onProgress,
+  }) {
+    final cached = _cache[originalPath];
+    if (cached != null) {
+      onProgress?.call(1);
+      return Future<VideoProxyResult>.value(cached);
+    }
+
+    final existing = _jobs[originalPath];
+    if (existing != null) {
+      if (onProgress != null) {
+        existing.listeners.add(onProgress);
+      }
+      return existing.completer.future;
+    }
+
+    final job = _ProxyJob();
+    if (onProgress != null) {
+      job.listeners.add(onProgress);
+    }
+    _jobs[originalPath] = job;
+
+    job.subscription = VideoCompress.compressProgress$.listen((progress) {
+      final clamped = (progress.clamp(0, 100)) / 100;
+      for (final listener in List<void Function(double progress)>.of(job.listeners)) {
+        listener(clamped);
+      }
+    });
+
+    () async {
+      try {
+        final info = await VideoCompress.compressVideo(
+          originalPath,
+          quality: VideoQuality.MediumQuality,
+          includeAudio: true,
+        );
+        if (info == null || info.path == null) {
+          throw Exception('Unable to generate proxy for $originalPath');
+        }
+        final result =
+            VideoProxyResult(originalPath: originalPath, proxyPath: info.path!);
+        _cache[originalPath] = result;
+        for (final listener in List<void Function(double progress)>.of(job.listeners)) {
+          listener(1);
+        }
+        job.completer.complete(result);
+      } catch (error, stackTrace) {
+        job.completer.completeError(error, stackTrace);
+      } finally {
+        await job.subscription?.cancel();
+        _jobs.remove(originalPath);
+      }
+    }();
+
+    return job.completer.future;
+  }
+}
+
+class _ProxyJob {
+  _ProxyJob();
+
+  final Completer<VideoProxyResult> completer = Completer<VideoProxyResult>();
+  final List<void Function(double progress)> listeners =
+      <void Function(double progress)>[];
+  StreamSubscription<double>? subscription;
+}

--- a/lib/features/create/presentation/widgets/transcode_status.dart
+++ b/lib/features/create/presentation/widgets/transcode_status.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+class TranscodeProgressOverlay extends StatelessWidget {
+  const TranscodeProgressOverlay({super.key, required this.progress});
+
+  final double? progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final value = progress;
+    return Container(
+      color: Colors.black.withValues(alpha: 0.55),
+      alignment: Alignment.center,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text(
+            'Preparing lightweight preview…',
+            style: TextStyle(color: Colors.white, fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 12),
+          SizedBox(
+            width: 200,
+            child: LinearProgressIndicator(value: value),
+          ),
+          if (value != null) ...[
+            const SizedBox(height: 6),
+            Text(
+              '${(value * 100).clamp(0, 100).toStringAsFixed(0)}%',
+              style: const TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class TranscodeErrorBanner extends StatelessWidget {
+  const TranscodeErrorBanner({super.key, required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.7),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Text(
+          message,
+          style: const TextStyle(color: Colors.white70, fontSize: 12),
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   flutter_cache_manager: ^3.3.1
   connectivity_plus: ^7.0.0
   http: ^1.2.2
+  video_compress: ^3.1.3
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add a shared video proxy service powered by `video_compress` so heavy sources produce lightweight preview files with cached results and progress callbacks
- update the media picker workflow to detect unsafe resolutions/filesizes, use the proxy for playback, and surface progress/error messaging to the user
- update the media composer preview to rely on the proxy pipeline and reuse shared status overlays while keeping the original media for upload

## Testing
- `flutter pub get` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a8eba7008328a7177608998c055e