### PR TITLE
Update video proxy subscription handling

### DIFF
--- a/lib/features/create/domain/video_proxy_service.dart
+++ b/lib/features/create/domain/video_proxy_service.dart
@@ -103,7 +103,7 @@ class VideoProxyService {
     }
     _jobs[originalPath] = job;
 
-    job.subscription = VideoCompress.compressProgress$.listen((progress) {
+    job.subscription = VideoCompress.subscribe((progress) {
       final clamped = (progress.clamp(0, 100)) / 100;
       for (final listener in List<void Function(double progress)>.of(job.listeners)) {
         listener(clamped);
@@ -130,7 +130,7 @@ class VideoProxyService {
       } catch (error, stackTrace) {
         job.completer.completeError(error, stackTrace);
       } finally {
-        await job.subscription?.cancel();
+        job.subscription?.unsubscribe();
         _jobs.remove(originalPath);
       }
     }();
@@ -145,5 +145,5 @@ class _ProxyJob {
   final Completer<VideoProxyResult> completer = Completer<VideoProxyResult>();
   final List<void Function(double progress)> listeners =
       <void Function(double progress)>[];
-  StreamSubscription<double>? subscription;
+  Subscription? subscription;
 }


### PR DESCRIPTION
## Summary
- switch the video proxy progress listener to use the new `VideoCompress.subscribe` API and store the returned subscription
- update the proxy job to track the `Subscription` type from `video_compress` and unsubscribe when finished

## Testing
- `flutter analyze` *(fails: Flutter SDK not installed in container)*
- `flutter test` *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5af5e05608328892e334599154f51