### PR TITLE
Refine cover upload guard

### DIFF
--- a/lib/core/video/upload/video_upload_repository.dart
+++ b/lib/core/video/upload/video_upload_repository.dart
@@ -35,7 +35,8 @@ class VideoUploadRepository {
     File? cover,
     required VideoUploadRequest request,
   }) async {
-    final includeCover = cover != null && await cover.exists();
+    final coverFile = cover;
+    final includeCover = coverFile != null && await coverFile.exists();
     final session = await _createSession(
       request: request,
       includeCover: includeCover,
@@ -51,13 +52,13 @@ class VideoUploadRepository {
     await _uploadToSignedUrl(target: videoTarget, file: video);
     uploaded[VideoUploadAssetType.video] = videoTarget;
 
-    if (includeCover) {
+    if (includeCover && coverFile != null) {
       final coverTarget = session.targetFor(VideoUploadAssetType.cover);
       if (coverTarget == null) {
         throw HttpException('Upload session missing cover target.',
             uri: _videosUri);
       }
-      await _uploadToSignedUrl(target: coverTarget, file: cover!);
+      await _uploadToSignedUrl(target: coverTarget, file: coverFile);
       uploaded[VideoUploadAssetType.cover] = coverTarget;
     }
 


### PR DESCRIPTION
## Summary
- store the optional cover file in a local variable before computing whether to include it
- guard the cover upload branch with a null check and pass the file without a bang operator

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5af6cc6c88328904bc13f5dba7fe7