### PR TITLE
Make preview placeholder const

### DIFF
--- a/lib/features/create/presentation/post_details_screen.dart
+++ b/lib/features/create/presentation/post_details_screen.dart
@@ -505,9 +505,9 @@ class _PreviewPlaceholder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: const BoxDecoration(color: Colors.black26),
-      child: const Center(
+    return const DecoratedBox(
+      decoration: BoxDecoration(color: Colors.black26),
+      child: Center(
         child: Icon(
           Icons.image_outlined,
           color: Colors.white60,


### PR DESCRIPTION
## Summary
- update the preview placeholder widget in the post details screen to use a const DecoratedBox constructor

## Testing
- `flutter analyze` *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5af9aeef883289186f5548b0f1dcd