### PR TITLE
Make event placeholder box const

### DIFF
--- a/lib/features/events/presentation/widgets/event_media_preview.dart
+++ b/lib/features/events/presentation/widgets/event_media_preview.dart
@@ -120,7 +120,7 @@ class _EventPreviewPlaceholder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DecoratedBox(
+    return const DecoratedBox(
       decoration: const BoxDecoration(color: Colors.black26),
       child: const Center(
         child: Icon(


### PR DESCRIPTION
## Summary
- mark the placeholder DecoratedBox in the event media preview widget as const to satisfy linting

## Testing
- `flutter analyze` *(fails: flutter command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5afa205108328a596d85dabde3a59