### PR TITLE
Add video creation flow scaffolding

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -16,6 +16,9 @@ import '../../features/events/presentation/event_detail_screen.dart';
 import '../../features/events/presentation/events_feed_screen.dart';
 import '../../features/home/presentation/home_shell.dart';
 import '../../features/profile/presentation/profile_screen.dart';
+import '../../features/video/views/video_editor_page.dart';
+import '../../features/video/views/video_picker_page.dart';
+import '../../features/video/views/video_post_page.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'root');
 final _shellNavigatorKey =
@@ -125,6 +128,24 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         path: '/create/event',
         name: CreateEventScreen.routeName,
         builder: (context, state) => const CreateEventScreen(),
+      ),
+      GoRoute(
+        parentNavigatorKey: _rootNavigatorKey,
+        path: '/create/video',
+        name: VideoPickerPage.routeName,
+        builder: (context, state) => const VideoPickerPage(),
+        routes: [
+          GoRoute(
+            path: 'editor',
+            name: VideoEditorPage.routeName,
+            builder: (context, state) => const VideoEditorPage(),
+          ),
+          GoRoute(
+            path: 'post',
+            name: VideoPostPage.routeName,
+            builder: (context, state) => const VideoPostPage(),
+          ),
+        ],
       ),
       GoRoute(
         parentNavigatorKey: _rootNavigatorKey,

--- a/lib/features/video/models/video_timeline.dart
+++ b/lib/features/video/models/video_timeline.dart
@@ -1,0 +1,79 @@
+import 'dart:ui';
+
+/// Describes a set of non-destructive edits that can be applied to a video.
+class VideoTimeline {
+  const VideoTimeline({
+    required this.sourcePath,
+    this.trimStartMs,
+    this.trimEndMs,
+    this.cropRect,
+    this.filterId,
+    this.playbackSpeed = 1.0,
+    this.overlayItems = const <VideoOverlayItem>[],
+    this.coverTimeMs,
+  });
+
+  /// Creates an empty timeline for the provided [sourcePath].
+  factory VideoTimeline.initial(String sourcePath) =>
+      VideoTimeline(sourcePath: sourcePath);
+
+  /// Location of the original video on disk.
+  final String sourcePath;
+
+  /// Inclusive start trim position in milliseconds.
+  final int? trimStartMs;
+
+  /// Exclusive end trim position in milliseconds.
+  final int? trimEndMs;
+
+  /// The crop rectangle applied to the source video, if any.
+  final Rect? cropRect;
+
+  /// Identifier for the selected filter or LUT.
+  final String? filterId;
+
+  /// Playback speed multiplier.
+  final double playbackSpeed;
+
+  /// Overlays (stickers, text, etc.) positioned on the timeline.
+  final List<VideoOverlayItem> overlayItems;
+
+  /// Cover frame time in milliseconds.
+  final int? coverTimeMs;
+
+  VideoTimeline copyWith({
+    String? sourcePath,
+    int? trimStartMs,
+    int? trimEndMs,
+    Rect? cropRect,
+    String? filterId,
+    double? playbackSpeed,
+    List<VideoOverlayItem>? overlayItems,
+    int? coverTimeMs,
+  }) {
+    return VideoTimeline(
+      sourcePath: sourcePath ?? this.sourcePath,
+      trimStartMs: trimStartMs ?? this.trimStartMs,
+      trimEndMs: trimEndMs ?? this.trimEndMs,
+      cropRect: cropRect ?? this.cropRect,
+      filterId: filterId ?? this.filterId,
+      playbackSpeed: playbackSpeed ?? this.playbackSpeed,
+      overlayItems: overlayItems ?? this.overlayItems,
+      coverTimeMs: coverTimeMs ?? this.coverTimeMs,
+    );
+  }
+}
+
+/// Describes a single overlay element applied on top of the video timeline.
+class VideoOverlayItem {
+  const VideoOverlayItem({
+    required this.id,
+    this.label,
+  });
+
+  /// Unique identifier for the overlay.
+  final String id;
+
+  /// Optional developer-friendly label.
+  final String? label;
+}

--- a/lib/features/video/providers/video_timeline_provider.dart
+++ b/lib/features/video/providers/video_timeline_provider.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/video_timeline.dart';
+
+class VideoTimelineNotifier extends Notifier<VideoTimeline?> {
+  @override
+  VideoTimeline? build() => null;
+
+  void loadSource(String sourcePath) {
+    state = VideoTimeline.initial(sourcePath);
+  }
+
+  void updateTimeline(VideoTimeline timeline) {
+    state = timeline;
+  }
+
+  void updateTrim({int? startMs, int? endMs}) {
+    final current = state;
+    if (current == null) {
+      return;
+    }
+    state = current.copyWith(
+      trimStartMs: startMs ?? current.trimStartMs,
+      trimEndMs: endMs ?? current.trimEndMs,
+    );
+  }
+
+  void setPlaybackSpeed(double speed) {
+    final current = state;
+    if (current == null) {
+      return;
+    }
+    state = current.copyWith(playbackSpeed: speed);
+  }
+
+  void setFilter(String? filterId) {
+    final current = state;
+    if (current == null) {
+      return;
+    }
+    state = current.copyWith(filterId: filterId);
+  }
+
+  void reset() {
+    final current = state;
+    if (current == null) {
+      return;
+    }
+    state = VideoTimeline.initial(current.sourcePath);
+  }
+}
+
+final videoTimelineProvider =
+    NotifierProvider<VideoTimelineNotifier, VideoTimeline?>(
+  VideoTimelineNotifier.new,
+);

--- a/lib/features/video/views/video_editor_page.dart
+++ b/lib/features/video/views/video_editor_page.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../providers/video_timeline_provider.dart';
+import 'video_post_page.dart';
+
+class VideoEditorPage extends ConsumerWidget {
+  const VideoEditorPage({super.key});
+
+  static const routeName = 'video-editor';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final timeline = ref.watch(videoTimelineProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edit video')),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (timeline == null)
+              const Text('Select a clip to begin editing')
+            else
+              Text('Editing ${timeline.sourcePath}'),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: timeline == null
+                  ? null
+                  : () => context.goNamed(VideoPostPage.routeName),
+              child: const Text('Continue'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/video/views/video_picker_page.dart
+++ b/lib/features/video/views/video_picker_page.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../providers/video_timeline_provider.dart';
+import 'video_editor_page.dart';
+
+class VideoPickerPage extends ConsumerWidget {
+  const VideoPickerPage({super.key});
+
+  static const routeName = 'video-picker';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Select video')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            // In a real implementation this would invoke a gallery picker.
+            ref.read(videoTimelineProvider.notifier).loadSource('mock/path.mp4');
+            context.goNamed(VideoEditorPage.routeName);
+          },
+          child: const Text('Pick from gallery'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/video/views/video_post_page.dart
+++ b/lib/features/video/views/video_post_page.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/video_timeline_provider.dart';
+
+class VideoPostPage extends ConsumerStatefulWidget {
+  const VideoPostPage({super.key});
+
+  static const routeName = 'video-post';
+
+  @override
+  ConsumerState<VideoPostPage> createState() => _VideoPostPageState();
+}
+
+class _VideoPostPageState extends ConsumerState<VideoPostPage> {
+  final _captionController = TextEditingController();
+  bool _isPrivate = false;
+
+  @override
+  void dispose() {
+    _captionController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final timeline = ref.watch(videoTimelineProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Post video')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _captionController,
+              decoration: const InputDecoration(labelText: 'Caption'),
+            ),
+            SwitchListTile(
+              value: _isPrivate,
+              title: const Text('Private'),
+              onChanged: (value) {
+                setState(() {
+                  _isPrivate = value;
+                });
+              },
+            ),
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: timeline == null
+                    ? null
+                    : () {
+                        // In the real flow this would trigger upload logic.
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Video posted!')),
+                        );
+                        Navigator.of(context).pop();
+                      },
+                child: const Text('Post'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold a video feature module with a non-destructive timeline model and notifier provider
- add placeholder picker, editor, and post views for the video creation flow
- register the /create/video route group in the router to wire the new flow

## Testing
- dart format lib/features/video lib/core/routing/app_router.dart *(fails: `dart` not available in environment)*
- flutter test *(fails: `flutter` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bb004840832899d36887a1f64d9c