### PR TITLE
Add Media3 dependencies to Android module

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -42,3 +42,9 @@ android {
 flutter {
     source = "../.."
 }
+
+dependencies {
+    implementation("androidx.media3:media3-exoplayer:1.4.1")
+    implementation("androidx.media3:media3-transformer:1.4.1")
+    implementation("androidx.media3:media3-effect:1.4.1")
+}


### PR DESCRIPTION
## Summary
- add the Media3 ExoPlayer, Transformer, and Effect dependencies to the Android app module build script
- confirm that the shared repository configuration already includes the Google Maven repository

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5bb92580c83288152701a82c1d045