### PR TITLE
Update iOS usage descriptions for photo and camera access

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -42,7 +42,9 @@
                 <string>UIInterfaceOrientationLandscapeRight</string>
         </array>
         <key>NSPhotoLibraryUsageDescription</key>
-        <string>This app needs access to your photo library to let you share images and videos.</string>
+        <string>Allow access to your photo library to pick and edit videos.</string>
+        <key>NSCameraUsageDescription</key>
+        <string>Allow camera access to record videos.</string>
         <key>NSPhotoLibraryAddUsageDescription</key>
         <string>Photo access is required to add content from your library to your creations.</string>
         <key>CADisableMinimumFrameDurationOnPhone</key>


### PR DESCRIPTION
## Summary
- update the iOS photo library usage description copy
- declare a camera usage description for video recording permissions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5bbac8e4c83288d585d7736f11d09