### PR TITLE
Add VideoNative platform channel interface

### DIFF
--- a/lib/features/video/platform/video_native.dart
+++ b/lib/features/video/platform/video_native.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/services.dart';
+
+class VideoNative {
+  static const _ch = MethodChannel('video_native');
+
+  static Future<String> generateCoverImage(
+    String filePath, {
+    required double seconds,
+  }) async {
+    final result = await _ch.invokeMethod<String>(
+      'generateCoverImage',
+      <String, dynamic>{
+        'filePath': filePath,
+        'seconds': seconds,
+      },
+    );
+    return result!;
+  }
+
+  static Future<String> exportEdits({
+    required String filePath,
+    required Map<String, dynamic> timelineJson,
+    required int targetBitrateBps,
+  }) async {
+    final result = await _ch.invokeMethod<String>(
+      'exportEdits',
+      <String, dynamic>{
+        'filePath': filePath,
+        'timelineJson': timelineJson,
+        'targetBitrateBps': targetBitrateBps,
+      },
+    );
+    return result!;
+  }
+
+  static Future<void> cancelExport() {
+    return _ch.invokeMethod<void>('cancelExport');
+  }
+}


### PR DESCRIPTION
## Summary
- add `VideoNative` platform channel helper for generating cover images, exporting edits, and cancelling export
- expose methods backed by `MethodChannel('video_native')`

## Testing
- dart format lib/features/video/platform/video_native.dart *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bbd6bdb48328b39f7e1dc6975df0