### PR TITLE
Add SurfaceView-backed ExoPlayer preview view

### DIFF
--- a/android/app/src/main/kotlin/com/example/coalition_mobile_app/VideoPreviewView.kt
+++ b/android/app/src/main/kotlin/com/example/coalition_mobile_app/VideoPreviewView.kt
@@ -1,0 +1,47 @@
+package com.example.coalition_mobile_app
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.SurfaceView
+import android.widget.FrameLayout
+import androidx.media3.exoplayer.ExoPlayer
+
+class VideoPreviewView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    private val surfaceView = SurfaceView(context)
+    private var player: ExoPlayer? = null
+
+    init {
+        surfaceView.layoutParams = LayoutParams(
+            LayoutParams.MATCH_PARENT,
+            LayoutParams.MATCH_PARENT,
+        )
+        surfaceView.holder.setKeepScreenOn(true)
+        addView(surfaceView)
+    }
+
+    fun setPlayer(player: ExoPlayer?) {
+        if (this.player === player) {
+            return
+        }
+
+        this.player?.clearVideoSurfaceView(surfaceView)
+        this.player = player
+
+        player?.setVideoSurfaceView(surfaceView)
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        player?.setVideoSurfaceView(surfaceView)
+    }
+
+    override fun onDetachedFromWindow() {
+        player?.clearVideoSurfaceView(surfaceView)
+        super.onDetachedFromWindow()
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `VideoPreviewView` that hosts a `SurfaceView` for ExoPlayer playback
- ensure the view attaches/detaches the `SurfaceView` via `setVideoSurfaceView`/`clearVideoSurfaceView` to avoid texture usage

## Testing
- `./gradlew lint` *(fails: `./gradlew` missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c1cbb6c483288100ac8c0610e048