### PR TITLE
Add Mux direct upload client and integrate post flow

### DIFF
--- a/lib/features/video/models/mux_dtos.dart
+++ b/lib/features/video/models/mux_dtos.dart
@@ -1,0 +1,45 @@
+class CreateMuxUploadRequest {
+  final String filename;
+  final int filesize;
+  final String contentType;
+  final bool preferTus;
+
+  CreateMuxUploadRequest({
+    required this.filename,
+    required this.filesize,
+    required this.contentType,
+    this.preferTus = true,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'filename': filename,
+        'filesize': filesize,
+        'content_type': contentType,
+        'prefer_tus': preferTus,
+      };
+}
+
+class CreateMuxUploadResponse {
+  final String uploadId;
+  final String? method;
+  final String? url;
+  final Map<String, dynamic>? tus;
+
+  CreateMuxUploadResponse({
+    required this.uploadId,
+    this.method,
+    this.url,
+    this.tus,
+  });
+
+  factory CreateMuxUploadResponse.fromJson(Map<String, dynamic> json) {
+    return CreateMuxUploadResponse(
+      uploadId: json['upload_id'] as String,
+      method: json['method'] as String?,
+      url: json['url'] as String?,
+      tus: json['tus'] != null
+          ? Map<String, dynamic>.from(json['tus'] as Map)
+          : null,
+    );
+  }
+}

--- a/lib/features/video/services/mux_upload_service.dart
+++ b/lib/features/video/services/mux_upload_service.dart
@@ -1,0 +1,219 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:tus_client/tus_client.dart';
+
+import '../../../core/config/backend_config_loader.dart';
+import '../../../core/config/backend_config_provider.dart';
+import '../models/mux_dtos.dart';
+
+typedef ProgressCallback = void Function(int sentBytes, int totalBytes);
+
+const bool kUseMux = true;
+
+class MuxUploadTicket {
+  final String uploadId; // Mux direct_upload id (from backend)
+  final String? method; // "POST" or "PUT" for simple uploads (if provided)
+  final Uri? url; // simple upload URL
+  final Uri? tusUrl; // tus endpoint if resumable
+  final Map<String, String> tusHeaders; // e.g. Authorization if needed
+
+  MuxUploadTicket({
+    required this.uploadId,
+    this.method,
+    this.url,
+    this.tusUrl,
+    this.tusHeaders = const {},
+  });
+
+  factory MuxUploadTicket.fromJson(Map<String, dynamic> j) {
+    return MuxUploadTicket(
+      uploadId: j['upload_id'] as String,
+      method: j['method'] as String?,
+      url: j['url'] != null ? Uri.parse(j['url']) : null,
+      tusUrl: j['tus']?['url'] != null ? Uri.parse(j['tus']['url']) : null,
+      tusHeaders: j['tus']?['headers'] != null
+          ? Map<String, String>.from(j['tus']['headers'])
+          : const {},
+    );
+  }
+
+  bool get isTus => tusUrl != null;
+}
+
+class MuxUploadResult {
+  final String uploadId; // same as ticket.uploadId
+  final int bytesSent;
+  const MuxUploadResult({required this.uploadId, required this.bytesSent});
+}
+
+abstract class MuxUploadService {
+  /// Calls *your backend* to mint a Direct Upload (simple or tus) and returns the ticket.
+  Future<MuxUploadTicket> createDirectUpload({
+    required String filename,
+    required int filesizeBytes,
+    String contentType = 'video/mp4',
+    bool preferTus = true,
+  });
+
+  /// Uploads the MP4 to Mux using the ticket (simple or tus). Progress optional.
+  Future<MuxUploadResult> uploadVideo({
+    required MuxUploadTicket ticket,
+    required File mp4,
+    ProgressCallback? onProgress,
+  });
+}
+
+final muxUploadServiceProvider = Provider<MuxUploadService>((ref) {
+  final config = ref.watch(backendConfigProvider);
+  final client = http.Client();
+  ref.onDispose(client.close);
+  return MuxUploadServiceHttp(client: client, config: config);
+});
+
+class MuxUploadServiceHttp implements MuxUploadService {
+  MuxUploadServiceHttp({required http.Client client, required BackendConfig config})
+      : _client = client,
+        _config = config;
+
+  final http.Client _client;
+  final BackendConfig _config;
+
+  Uri get _muxBaseUri => _ensureTrailingSlash(_config.baseUri).resolve('mux/');
+
+  @override
+  Future<MuxUploadTicket> createDirectUpload({
+    required String filename,
+    required int filesizeBytes,
+    String contentType = 'video/mp4',
+    bool preferTus = true,
+  }) async {
+    final uri = _muxBaseUri.resolve('direct-uploads');
+    final requestDto = CreateMuxUploadRequest(
+      filename: filename,
+      filesize: filesizeBytes,
+      contentType: contentType,
+      preferTus: preferTus,
+    );
+    final response = await _client.post(
+      uri,
+      headers: const {'content-type': 'application/json'},
+      body: jsonEncode(requestDto.toJson()),
+    );
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException(
+        'Failed to create Mux upload: ${response.statusCode} ${response.reasonPhrase}\n${response.body}',
+        uri: uri,
+      );
+    }
+
+    final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+    final responseDto = CreateMuxUploadResponse.fromJson(decoded);
+
+    return MuxUploadTicket(
+      uploadId: responseDto.uploadId,
+      method: responseDto.method,
+      url: responseDto.url != null ? Uri.parse(responseDto.url!) : null,
+      tusUrl: responseDto.tus != null && responseDto.tus!['url'] != null
+          ? Uri.parse(responseDto.tus!['url'] as String)
+          : null,
+      tusHeaders: responseDto.tus != null && responseDto.tus!['headers'] != null
+          ? Map<String, String>.from(
+              (responseDto.tus!['headers'] as Map<dynamic, dynamic>).map(
+                (key, value) => MapEntry(key.toString(), value.toString()),
+              ),
+            )
+          : const {},
+    );
+  }
+
+  @override
+  Future<MuxUploadResult> uploadVideo({
+    required MuxUploadTicket ticket,
+    required File mp4,
+    ProgressCallback? onProgress,
+  }) async {
+    if (ticket.isTus) {
+      final tusUrl = ticket.tusUrl;
+      if (tusUrl == null) {
+        throw StateError('Ticket marked as tus but missing endpoint.');
+      }
+      final client = TusClient(
+        tusUrl.toString(),
+        headers: ticket.tusHeaders,
+      );
+      final upload = await client.createOrResumeUpload(mp4);
+      upload.onProgress = (sent, total) => onProgress?.call(sent, total);
+      await client.upload(upload);
+      return MuxUploadResult(
+        uploadId: ticket.uploadId,
+        bytesSent: await mp4.length(),
+      );
+    }
+
+    final uploadUrl = ticket.url;
+    if (uploadUrl == null) {
+      throw StateError('Ticket missing direct upload URL.');
+    }
+    final method = (ticket.method ?? 'POST').toUpperCase();
+    final totalBytes = await mp4.length();
+    final request = http.StreamedRequest(method, uploadUrl)
+      ..headers['content-type'] = 'video/mp4'
+      ..contentLength = totalBytes;
+
+    final completer = Completer<void>();
+    var sentBytes = 0;
+    final subscription = mp4.openRead().listen(
+      (chunk) {
+        request.sink.add(chunk);
+        sentBytes += chunk.length;
+        onProgress?.call(sentBytes, totalBytes);
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        request.sink.close();
+        if (!completer.isCompleted) {
+          completer.completeError(error, stackTrace);
+        }
+      },
+      onDone: () {
+        request.sink.close();
+        if (!completer.isCompleted) {
+          completer.complete();
+        }
+      },
+      cancelOnError: true,
+    );
+
+    try {
+      final responseFuture = _client.send(request);
+      await completer.future;
+      final response = await responseFuture;
+      await response.stream.drain();
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw HttpException(
+          'Mux upload failed: ${response.statusCode} ${response.reasonPhrase}',
+          uri: uploadUrl,
+        );
+      }
+    } finally {
+      await subscription.cancel();
+    }
+
+    return MuxUploadResult(
+      uploadId: ticket.uploadId,
+      bytesSent: totalBytes,
+    );
+  }
+
+  Uri _ensureTrailingSlash(Uri uri) {
+    if (uri.path.endsWith('/')) {
+      return uri;
+    }
+    final path = uri.path.isEmpty ? '/' : '${uri.path}/';
+    return uri.replace(path: path);
+  }
+}

--- a/lib/features/video/views/video_post_page.dart
+++ b/lib/features/video/views/video_post_page.dart
@@ -1,9 +1,15 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
 
+import '../../../core/config/backend_config_provider.dart';
 import '../models/video_timeline.dart';
 import '../platform/video_native.dart';
 import '../providers/video_timeline_provider.dart';
+import '../services/mux_upload_service.dart';
 
 class VideoPostPage extends ConsumerStatefulWidget {
   const VideoPostPage({super.key});
@@ -14,55 +20,44 @@ class VideoPostPage extends ConsumerStatefulWidget {
   ConsumerState<VideoPostPage> createState() => _VideoPostPageState();
 }
 
+enum _PostStage { idle, exporting, uploading, processing }
+
 class _VideoPostPageState extends ConsumerState<VideoPostPage> {
+  _PostStage _stage = _PostStage.idle;
   final _captionController = TextEditingController();
+  late final http.Client _httpClient;
   bool _isPrivate = false;
-  bool _isExporting = false;
+  bool _uploadFailed = false;
+  double _uploadProgress = 0;
+  File? _exportedVideoFile;
+  String? _localCoverPath;
+  String? _uploadedCoverUrl;
+  MuxUploadTicket? _currentTicket;
+  bool _uploadCompleted = false;
   String? _errorMessage;
 
   @override
+  void initState() {
+    super.initState();
+    _httpClient = http.Client();
+  }
+
+  @override
   void dispose() {
+    _httpClient.close();
     _captionController.dispose();
     super.dispose();
   }
 
   Future<void> _onPostPressed(VideoTimeline timeline) async {
-    setState(() {
-      _isExporting = true;
-      _errorMessage = null;
-    });
-
-    try {
-      final timelineJson = _buildTimelineJson(timeline);
-      final exportedPath = await VideoNative.exportEdits(
-        filePath: timeline.sourcePath,
-        timelineJson: timelineJson,
-        targetBitrateBps: 6_000_000,
-      );
-
-      final coverPath = timeline.coverImagePath;
-
-      await _uploadVideo(exportedPath, coverPath);
-
-      if (!mounted) return;
+    if (!kUseMux) {
       setState(() {
-        _isExporting = false;
+        _errorMessage = 'Video uploads are currently unavailable.';
       });
-
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Video posted!')),
-      );
-      Navigator.of(context).pop();
-    } catch (error, stackTrace) {
-      // In a production environment this would be reported to crash logging.
-      debugPrint('Failed to export video: $error\n$stackTrace');
-      if (!mounted) return;
-      setState(() {
-        _isExporting = false;
-        _errorMessage = 'Failed to export video. Please try again.';
-      });
+      return;
     }
+
+    await _startMuxPostFlow(timeline);
   }
 
   Map<String, dynamic> _buildTimelineJson(VideoTimeline timeline) {
@@ -93,15 +88,348 @@ class _VideoPostPageState extends ConsumerState<VideoPostPage> {
     return map;
   }
 
-  Future<void> _uploadVideo(String videoPath, String? coverImagePath) {
-    // TODO: Replace with upload service integration. This will hand off the
-    // exported MP4 at [videoPath] and the optional PNG cover at [coverImagePath].
-    return Future<void>.value();
+  Future<void> _startMuxPostFlow(VideoTimeline timeline) async {
+    final existing = _exportedVideoFile;
+    var hasExported = false;
+    if (existing != null && existing.existsSync()) {
+      hasExported = true;
+    } else {
+      _exportedVideoFile = null;
+    }
+
+    final needsExport = !hasExported;
+    final needsUpload = !_uploadCompleted;
+
+    setState(() {
+      _errorMessage = null;
+      _uploadFailed = false;
+      if (needsExport) {
+        _stage = _PostStage.exporting;
+      } else if (needsUpload) {
+        _stage = _PostStage.uploading;
+        _uploadProgress = 0;
+      } else {
+        _stage = _PostStage.processing;
+      }
+    });
+
+    var uploadAttempted = false;
+    var postAttempted = false;
+
+    try {
+      final videoFile = await _ensureExportedVideo(timeline);
+      final coverPath = await _ensureCoverImage(timeline);
+      final coverUrl = await _ensureCoverUpload(coverPath);
+      final ticket = await _ensureMuxTicket(videoFile);
+
+      if (!_uploadCompleted) {
+        uploadAttempted = true;
+        await _performMuxUpload(ticket, videoFile);
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _uploadCompleted = true;
+          _uploadProgress = 1.0;
+        });
+      }
+
+      postAttempted = true;
+      await _postToBackend(
+        uploadId: ticket.uploadId,
+        coverUrl: coverUrl,
+        timeline: timeline,
+      );
+
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Processing video…')),
+      );
+      Navigator.of(context).pop();
+    } catch (error, stackTrace) {
+      // In a production environment this would be reported to crash logging.
+      debugPrint('Failed to post video: $error\n$stackTrace');
+      final isTusTicket = _currentTicket?.isTus == true;
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _stage = _PostStage.idle;
+        _uploadProgress = 0;
+        _uploadFailed = uploadAttempted || postAttempted;
+        if (_uploadFailed && _currentTicket != null && !_currentTicket!.isTus && !_uploadCompleted) {
+          _currentTicket = null;
+        }
+        _errorMessage =
+            _messageForError(uploadAttempted: uploadAttempted, postAttempted: postAttempted, isTusTicket: isTusTicket);
+      });
+    }
+  }
+
+  String _messageForError({
+    required bool uploadAttempted,
+    required bool postAttempted,
+    required bool isTusTicket,
+  }) {
+    if (postAttempted) {
+      return 'Failed to create post. Please try again.';
+    }
+    if (uploadAttempted) {
+      return isTusTicket
+          ? 'Upload interrupted. Tap “Resume upload” to continue.'
+          : 'Upload failed. Tap “Retry upload” to try again.';
+    }
+    return 'Failed to prepare video. Please try again.';
+  }
+
+  Future<File> _ensureExportedVideo(VideoTimeline timeline) async {
+    final existing = _exportedVideoFile;
+    if (existing != null && await existing.exists()) {
+      return existing;
+    }
+
+    final timelineJson = _buildTimelineJson(timeline);
+    final exportedPath = await VideoNative.exportEdits(
+      filePath: timeline.sourcePath,
+      timelineJson: timelineJson,
+      targetBitrateBps: 6_000_000,
+    );
+
+    final file = File(exportedPath);
+    _exportedVideoFile = file;
+    _uploadCompleted = false;
+    return file;
+  }
+
+  Future<String> _ensureCoverImage(VideoTimeline timeline) async {
+    final cached = _localCoverPath ?? timeline.coverImagePath;
+    if (cached != null && cached.isNotEmpty) {
+      _localCoverPath = cached;
+      return cached;
+    }
+
+    final seconds = (timeline.coverTimeMs ?? 0) / 1000;
+    final coverPath = await VideoNative.generateCoverImage(
+      timeline.sourcePath,
+      seconds: seconds,
+    );
+    _localCoverPath = coverPath;
+    return coverPath;
+  }
+
+  Future<String> _ensureCoverUpload(String coverPath) async {
+    final cached = _uploadedCoverUrl;
+    if (cached != null && cached.isNotEmpty) {
+      return cached;
+    }
+    final uploaded = await _uploadCoverImage(coverPath);
+    _uploadedCoverUrl = uploaded;
+    return uploaded;
+  }
+
+  Future<String> _uploadCoverImage(String coverPath) async {
+    final file = File(coverPath);
+    if (!await file.exists()) {
+      throw FileSystemException('Cover image missing', coverPath);
+    }
+
+    final uri = _resolveBackendUri('assets/covers/presign');
+    final response = await _httpClient.post(
+      uri,
+      headers: const {'content-type': 'application/json'},
+      body: jsonEncode({
+        'filename': _basename(coverPath),
+        'content_type': 'image/png',
+      }),
+    );
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException(
+        'Failed to presign cover upload: ${response.statusCode} ${response.reasonPhrase}\n${response.body}',
+        uri: uri,
+      );
+    }
+
+    final payload = jsonDecode(response.body) as Map<String, dynamic>;
+    final uploadUrl = payload['put_url'] ?? payload['upload_url'] ?? payload['url'];
+    final assetUrl = payload['asset_url'] ?? payload['cover_url'] ?? payload['public_url'];
+    final headers = payload['headers'];
+
+    if (uploadUrl is! String || assetUrl is! String) {
+      throw const FormatException('Presign response missing upload target.');
+    }
+
+    final request = http.Request('PUT', Uri.parse(uploadUrl));
+    request.headers['content-type'] = 'image/png';
+    if (headers is Map) {
+      request.headers.addAll(headers.map(
+        (key, value) => MapEntry(key.toString(), value.toString()),
+      ));
+    }
+    request.bodyBytes = await file.readAsBytes();
+
+    final uploadResponse = await _httpClient.send(request);
+    await uploadResponse.stream.drain();
+    if (uploadResponse.statusCode < 200 || uploadResponse.statusCode >= 300) {
+      throw HttpException(
+        'Failed to upload cover: ${uploadResponse.statusCode} ${uploadResponse.reasonPhrase}',
+        uri: request.url,
+      );
+    }
+
+    return assetUrl;
+  }
+
+  Future<MuxUploadTicket> _ensureMuxTicket(File video) async {
+    final existing = _currentTicket;
+    if (existing != null) {
+      if (existing.isTus || _uploadCompleted) {
+        return existing;
+      }
+    }
+
+    final filesize = await video.length();
+    final ticket = await ref.read(muxUploadServiceProvider).createDirectUpload(
+          filename: _basename(video.path),
+          filesizeBytes: filesize,
+          contentType: 'video/mp4',
+          preferTus: true,
+        );
+    _currentTicket = ticket;
+    _uploadCompleted = false;
+    return ticket;
+  }
+
+  Future<void> _performMuxUpload(MuxUploadTicket ticket, File video) async {
+    setState(() {
+      _stage = _PostStage.uploading;
+      _uploadProgress = 0;
+    });
+
+    await ref.read(muxUploadServiceProvider).uploadVideo(
+          ticket: ticket,
+          mp4: video,
+          onProgress: (sent, total) {
+            if (!mounted) {
+              return;
+            }
+            setState(() {
+              _uploadProgress = total <= 0 ? 0 : (sent / total).clamp(0, 1);
+            });
+          },
+        );
+  }
+
+  Future<void> _postToBackend({
+    required String uploadId,
+    required String coverUrl,
+    required VideoTimeline timeline,
+  }) async {
+    setState(() {
+      _stage = _PostStage.processing;
+    });
+
+    final uri = _resolveBackendUri('posts');
+    final response = await _httpClient.post(
+      uri,
+      headers: const {'content-type': 'application/json'},
+      body: jsonEncode({
+        'mux_upload_id': uploadId,
+        'cover_url': coverUrl,
+        'caption': _captionController.text.trim(),
+        'duration_ms': _calculateDurationMs(timeline),
+        'source_device': Platform.isIOS ? 'ios' : 'android',
+      }),
+    );
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException(
+        'Failed to create post: ${response.statusCode} ${response.reasonPhrase}\n${response.body}',
+        uri: uri,
+      );
+    }
+  }
+
+  int _calculateDurationMs(VideoTimeline timeline) {
+    final start = timeline.trimStartMs ?? 0;
+    final end = timeline.trimEndMs;
+    if (end != null && end > start) {
+      return end - start;
+    }
+    final coverTime = timeline.coverTimeMs;
+    if (coverTime != null && coverTime > start) {
+      return coverTime - start;
+    }
+    return 0;
+  }
+
+  Uri _resolveBackendUri(String path) {
+    final config = ref.read(backendConfigProvider);
+    return _ensureTrailingSlash(config.baseUri).resolve(path);
+  }
+
+  Uri _ensureTrailingSlash(Uri uri) {
+    if (uri.path.endsWith('/')) {
+      return uri;
+    }
+    final path = uri.path.isEmpty ? '/' : '${uri.path}/';
+    return uri.replace(path: path);
+  }
+
+  String _basename(String path) {
+    final normalized = path.replaceAll('\\', '/');
+    final segments = normalized.split('/');
+    return segments.isNotEmpty ? segments.last : path;
+  }
+
+  String _statusLabel() {
+    switch (_stage) {
+      case _PostStage.exporting:
+        return 'Exporting video…';
+      case _PostStage.uploading:
+        final percent = (_uploadProgress * 100).clamp(0, 100).toStringAsFixed(0);
+        return _uploadProgress > 0
+            ? 'Uploading video… $percent%'
+            : 'Uploading video…';
+      case _PostStage.processing:
+        return 'Processing video…';
+      case _PostStage.idle:
+        return '';
+    }
+  }
+
+  String _primaryButtonLabel() {
+    switch (_stage) {
+      case _PostStage.exporting:
+        return 'Exporting…';
+      case _PostStage.uploading:
+        return 'Uploading…';
+      case _PostStage.processing:
+        return 'Processing…';
+      case _PostStage.idle:
+        if (_uploadFailed) {
+          if (_uploadCompleted) {
+            return 'Retry';
+          }
+          return _currentTicket?.isTus == true ? 'Resume upload' : 'Retry upload';
+        }
+        return 'Post';
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final timeline = ref.watch(videoTimelineProvider);
+    final isBusy =
+        _stage == _PostStage.exporting || _stage == _PostStage.uploading || _stage == _PostStage.processing;
+    final double? progressValue = _stage == _PostStage.uploading
+        ? (_uploadProgress.clamp(0.0, 1.0) as double)
+        : null;
+    final buttonLabel = _primaryButtonLabel();
+    final VoidCallback? buttonOnPressed =
+        timeline == null || isBusy ? null : () => _onPostPressed(timeline);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Post video')),
@@ -113,12 +441,12 @@ class _VideoPostPageState extends ConsumerState<VideoPostPage> {
             TextField(
               controller: _captionController,
               decoration: const InputDecoration(labelText: 'Caption'),
-              enabled: !_isExporting,
+              enabled: !isBusy,
             ),
             SwitchListTile(
               value: _isPrivate,
               title: const Text('Private'),
-              onChanged: _isExporting
+              onChanged: isBusy
                   ? null
                   : (value) {
                       setState(() {
@@ -126,11 +454,14 @@ class _VideoPostPageState extends ConsumerState<VideoPostPage> {
                       });
                     },
             ),
-            if (_isExporting) ...[
+            if (isBusy) ...[
               const SizedBox(height: 16),
-              const LinearProgressIndicator(),
+              LinearProgressIndicator(value: progressValue),
               const SizedBox(height: 8),
-              const Text('Exporting video...'),
+              Text(
+                _statusLabel(),
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
             ],
             if (_errorMessage != null) ...[
               const SizedBox(height: 16),
@@ -146,10 +477,8 @@ class _VideoPostPageState extends ConsumerState<VideoPostPage> {
             SizedBox(
               width: double.infinity,
               child: ElevatedButton(
-                onPressed: timeline == null || _isExporting
-                    ? null
-                    : () => _onPostPressed(timeline),
-                child: const Text('Post'),
+                onPressed: buttonOnPressed,
+                child: Text(buttonLabel),
               ),
             ),
           ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   flutter_cache_manager: ^3.3.1
   connectivity_plus: ^7.0.0
   http: ^1.2.2
+  tus_client: ^2.0.0
   video_compress: ^3.1.3
   mime: ^1.0.6
 


### PR DESCRIPTION
## Summary
- add DTOs and an HTTP-backed Mux upload service with tus and simple upload handling
- integrate the Mux flow into the video post page with export/upload/processing states, cover upload, and backend post creation
- add the tus_client dependency for resumable uploads

## Testing
- flutter pub get *(fails: command not found in container)*
- dart format lib/features/video/models/mux_dtos.dart lib/features/video/services/mux_upload_service.dart lib/features/video/views/video_post_page.dart *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c5ec4f588328b754a5ac09a31d17