### PR TITLE
Add minimal Mux backend service

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,1096 @@
+{
+  "name": "coalition-backend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "coalition-backend",
+      "dependencies": {
+        "@mux/mux-node": "^7.3.5",
+        "body-parser": "^1.20.3",
+        "dotenv": "^16.4.5",
+        "express": "^4.19.2"
+      }
+    },
+    "node_modules/@mux/mux-node": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@mux/mux-node/-/mux-node-7.3.5.tgz",
+      "integrity": "sha512-lM0DIKiNAQoT0jBCuOfbzwfky4UYrF9h2xbidEYT/I2ftO2q4891+5dFXDUmi1IJtsdIxRARsggZKqrwdsd4Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.2.6",
+        "esdoc-ecmascript-proposal-plugin": "^1.0.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/esdoc-ecmascript-proposal-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esdoc-ecmascript-proposal-plugin/-/esdoc-ecmascript-proposal-plugin-1.0.0.tgz",
+      "integrity": "sha512-PuaU/O8d+Sb0J6qQdyhmy74h/2cp/2kqsvPuoCiK+50Rw54nlGqXxvWNaaNikS5qntE0FfssnwZtUPa6q4RiXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "coalition-backend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node src/server.js"
+  },
+  "dependencies": {
+    "@mux/mux-node": "^7.3.5",
+    "express": "^4.19.2",
+    "body-parser": "^1.20.3",
+    "dotenv": "^16.4.5"
+  }
+}

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,113 @@
+import 'dotenv/config';
+import express from 'express';
+import bodyParser from 'body-parser';
+import muxPkg from '@mux/mux-node';
+const { Mux, Webhooks } = muxPkg;
+
+const app = express();
+
+// JSON for normal routes:
+app.use('/api', bodyParser.json());
+
+// RAW body for webhook signature verification:
+app.use('/webhooks/mux', bodyParser.raw({ type: '*/*' }));
+
+// CORS (narrow if you know your origins)
+const ALLOWED = process.env.ALLOWED_CORS_ORIGIN || '*';
+app.use((req, res, next) => {
+  res.setHeader('Access-Control-Allow-Origin', ALLOWED);
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+  if (req.method === 'OPTIONS') return res.sendStatus(200);
+  next();
+});
+
+// Mux client (reads MUX_TOKEN_ID/SECRET from env automatically)
+const mux = new Mux();
+
+// --- 1) Create Direct Upload URL ---
+// POST /api/mux/direct-uploads
+app.post('/api/mux/direct-uploads', async (req, res) => {
+  try {
+    const { filename, filesize, content_type = 'video/mp4', cors_origin } = req.body || {};
+
+    // (Optional) create your own application-side ID and store it to map later
+    // e.g., const draftPostId = await db.createDraft({ filename, filesize, content_type })
+
+    const upload = await mux.video.uploads.create({
+      cors_origin: cors_origin || process.env.ALLOWED_CORS_ORIGIN || '*',
+      new_asset_settings: {
+        // Use passthrough to tie the future Asset/webhooks back to your app record:
+        // passthrough: draftPostId,
+        playback_policy: ['public'],
+        video_quality: 'basic'
+      }
+    });
+
+    // Respond with what the mobile app needs
+    return res.status(201).json({
+      upload_id: upload.id,
+      url: upload.url,     // client will PUT the file to this URL
+      method: 'PUT'
+    });
+  } catch (err) {
+    console.error('Mux upload create error', err);
+    return res.status(500).json({ error: 'failed_to_create_direct_upload' });
+  }
+});
+
+// --- 2) (Optional) Poll upload/asset status ---
+// GET /api/mux/uploads/:id
+app.get('/api/mux/uploads/:id', async (req, res) => {
+  try {
+    const u = await mux.video.uploads.retrieve(req.params.id);
+    return res.json(u);
+  } catch (err) {
+    return res.status(404).json({ error: 'not_found' });
+  }
+});
+
+// --- 3) Webhook to finalize posts ---
+// POST /webhooks/mux
+app.post('/webhooks/mux', async (req, res) => {
+  // Verify signature
+  const signature = req.headers['mux-signature'];
+  const secret = process.env.MUX_WEBHOOK_SECRET;
+  let event;
+  try {
+    Webhooks.verifyHeader(req.body, signature, secret);
+    event = JSON.parse(req.body.toString('utf8'));
+  } catch (err) {
+    console.error('Invalid Mux webhook signature', err);
+    return res.sendStatus(400);
+  }
+
+  try {
+    const { type, data } = event;
+
+    if (type === 'video.upload.asset_created') {
+      // data.asset_id exists; data.id is the Direct Upload id
+      // If you set new_asset_settings.passthrough when creating the upload,
+      // use data.passthrough to look up the draft post in your DB and attach asset_id.
+      // await db.markAssetCreated({ passthrough: data.passthrough, assetId: data.asset_id });
+    }
+
+    if (type === 'video.asset.ready') {
+      // Finalize your post: store playback info for the feed.
+      // Typical fields:
+      // - data.id (asset id)
+      // - data.playback_ids[0].id  => playback_id
+      // - build HLS URL: https://stream.mux.com/${playback_id}.m3u8
+      // await db.finalizePost({ passthrough: data.passthrough, playbackId, assetId: data.id });
+    }
+
+    // Handle other events as needed; always 200 quickly.
+    return res.sendStatus(200);
+  } catch (err) {
+    console.error('Webhook handling error', err);
+    return res.sendStatus(500);
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`Backend listening on :${port}`));

--- a/lib/features/video/models/mux_dtos.dart
+++ b/lib/features/video/models/mux_dtos.dart
@@ -1,0 +1,45 @@
+class CreateMuxUploadRequest {
+  final String filename;
+  final int filesize;
+  final String contentType;
+  final bool preferTus;
+
+  CreateMuxUploadRequest({
+    required this.filename,
+    required this.filesize,
+    required this.contentType,
+    this.preferTus = true,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'filename': filename,
+        'filesize': filesize,
+        'content_type': contentType,
+        'prefer_tus': preferTus,
+      };
+}
+
+class CreateMuxUploadResponse {
+  final String uploadId;
+  final String? method;
+  final String? url;
+  final Map<String, dynamic>? tus;
+
+  CreateMuxUploadResponse({
+    required this.uploadId,
+    this.method,
+    this.url,
+    this.tus,
+  });
+
+  factory CreateMuxUploadResponse.fromJson(Map<String, dynamic> json) {
+    return CreateMuxUploadResponse(
+      uploadId: json['upload_id'] as String,
+      method: json['method'] as String?,
+      url: json['url'] as String?,
+      tus: json['tus'] != null
+          ? Map<String, dynamic>.from(json['tus'] as Map)
+          : null,
+    );
+  }
+}

--- a/lib/features/video/services/mux_upload_service.dart
+++ b/lib/features/video/services/mux_upload_service.dart
@@ -1,0 +1,219 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:tus_client/tus_client.dart';
+
+import '../../../core/config/backend_config_loader.dart';
+import '../../../core/config/backend_config_provider.dart';
+import '../models/mux_dtos.dart';
+
+typedef ProgressCallback = void Function(int sentBytes, int totalBytes);
+
+const bool kUseMux = true;
+
+class MuxUploadTicket {
+  final String uploadId; // Mux direct_upload id (from backend)
+  final String? method; // "POST" or "PUT" for simple uploads (if provided)
+  final Uri? url; // simple upload URL
+  final Uri? tusUrl; // tus endpoint if resumable
+  final Map<String, String> tusHeaders; // e.g. Authorization if needed
+
+  MuxUploadTicket({
+    required this.uploadId,
+    this.method,
+    this.url,
+    this.tusUrl,
+    this.tusHeaders = const {},
+  });
+
+  factory MuxUploadTicket.fromJson(Map<String, dynamic> j) {
+    return MuxUploadTicket(
+      uploadId: j['upload_id'] as String,
+      method: j['method'] as String?,
+      url: j['url'] != null ? Uri.parse(j['url']) : null,
+      tusUrl: j['tus']?['url'] != null ? Uri.parse(j['tus']['url']) : null,
+      tusHeaders: j['tus']?['headers'] != null
+          ? Map<String, String>.from(j['tus']['headers'])
+          : const {},
+    );
+  }
+
+  bool get isTus => tusUrl != null;
+}
+
+class MuxUploadResult {
+  final String uploadId; // same as ticket.uploadId
+  final int bytesSent;
+  const MuxUploadResult({required this.uploadId, required this.bytesSent});
+}
+
+abstract class MuxUploadService {
+  /// Calls *your backend* to mint a Direct Upload (simple or tus) and returns the ticket.
+  Future<MuxUploadTicket> createDirectUpload({
+    required String filename,
+    required int filesizeBytes,
+    String contentType = 'video/mp4',
+    bool preferTus = true,
+  });
+
+  /// Uploads the MP4 to Mux using the ticket (simple or tus). Progress optional.
+  Future<MuxUploadResult> uploadVideo({
+    required MuxUploadTicket ticket,
+    required File mp4,
+    ProgressCallback? onProgress,
+  });
+}
+
+final muxUploadServiceProvider = Provider<MuxUploadService>((ref) {
+  final config = ref.watch(backendConfigProvider);
+  final client = http.Client();
+  ref.onDispose(client.close);
+  return MuxUploadServiceHttp(client: client, config: config);
+});
+
+class MuxUploadServiceHttp implements MuxUploadService {
+  MuxUploadServiceHttp({required http.Client client, required BackendConfig config})
+      : _client = client,
+        _config = config;
+
+  final http.Client _client;
+  final BackendConfig _config;
+
+  Uri get _muxBaseUri => _ensureTrailingSlash(_config.baseUri).resolve('mux/');
+
+  @override
+  Future<MuxUploadTicket> createDirectUpload({
+    required String filename,
+    required int filesizeBytes,
+    String contentType = 'video/mp4',
+    bool preferTus = true,
+  }) async {
+    final uri = _muxBaseUri.resolve('direct-uploads');
+    final requestDto = CreateMuxUploadRequest(
+      filename: filename,
+      filesize: filesizeBytes,
+      contentType: contentType,
+      preferTus: preferTus,
+    );
+    final response = await _client.post(
+      uri,
+      headers: const {'content-type': 'application/json'},
+      body: jsonEncode(requestDto.toJson()),
+    );
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException(
+        'Failed to create Mux upload: ${response.statusCode} ${response.reasonPhrase}\n${response.body}',
+        uri: uri,
+      );
+    }
+
+    final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+    final responseDto = CreateMuxUploadResponse.fromJson(decoded);
+
+    return MuxUploadTicket(
+      uploadId: responseDto.uploadId,
+      method: responseDto.method,
+      url: responseDto.url != null ? Uri.parse(responseDto.url!) : null,
+      tusUrl: responseDto.tus != null && responseDto.tus!['url'] != null
+          ? Uri.parse(responseDto.tus!['url'] as String)
+          : null,
+      tusHeaders: responseDto.tus != null && responseDto.tus!['headers'] != null
+          ? Map<String, String>.from(
+              (responseDto.tus!['headers'] as Map<dynamic, dynamic>).map(
+                (key, value) => MapEntry(key.toString(), value.toString()),
+              ),
+            )
+          : const {},
+    );
+  }
+
+  @override
+  Future<MuxUploadResult> uploadVideo({
+    required MuxUploadTicket ticket,
+    required File mp4,
+    ProgressCallback? onProgress,
+  }) async {
+    if (ticket.isTus) {
+      final tusUrl = ticket.tusUrl;
+      if (tusUrl == null) {
+        throw StateError('Ticket marked as tus but missing endpoint.');
+      }
+      final client = TusClient(
+        tusUrl.toString(),
+        headers: ticket.tusHeaders,
+      );
+      final upload = await client.createOrResumeUpload(mp4);
+      upload.onProgress = (sent, total) => onProgress?.call(sent, total);
+      await client.upload(upload);
+      return MuxUploadResult(
+        uploadId: ticket.uploadId,
+        bytesSent: await mp4.length(),
+      );
+    }
+
+    final uploadUrl = ticket.url;
+    if (uploadUrl == null) {
+      throw StateError('Ticket missing direct upload URL.');
+    }
+    final method = (ticket.method ?? 'POST').toUpperCase();
+    final totalBytes = await mp4.length();
+    final request = http.StreamedRequest(method, uploadUrl)
+      ..headers['content-type'] = 'video/mp4'
+      ..contentLength = totalBytes;
+
+    final completer = Completer<void>();
+    var sentBytes = 0;
+    final subscription = mp4.openRead().listen(
+      (chunk) {
+        request.sink.add(chunk);
+        sentBytes += chunk.length;
+        onProgress?.call(sentBytes, totalBytes);
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        request.sink.close();
+        if (!completer.isCompleted) {
+          completer.completeError(error, stackTrace);
+        }
+      },
+      onDone: () {
+        request.sink.close();
+        if (!completer.isCompleted) {
+          completer.complete();
+        }
+      },
+      cancelOnError: true,
+    );
+
+    try {
+      final responseFuture = _client.send(request);
+      await completer.future;
+      final response = await responseFuture;
+      await response.stream.drain();
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw HttpException(
+          'Mux upload failed: ${response.statusCode} ${response.reasonPhrase}',
+          uri: uploadUrl,
+        );
+      }
+    } finally {
+      await subscription.cancel();
+    }
+
+    return MuxUploadResult(
+      uploadId: ticket.uploadId,
+      bytesSent: totalBytes,
+    );
+  }
+
+  Uri _ensureTrailingSlash(Uri uri) {
+    if (uri.path.endsWith('/')) {
+      return uri;
+    }
+    final path = uri.path.isEmpty ? '/' : '${uri.path}/';
+    return uri.replace(path: path);
+  }
+}

--- a/lib/features/video/views/video_post_page.dart
+++ b/lib/features/video/views/video_post_page.dart
@@ -1,9 +1,15 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
 
+import '../../../core/config/backend_config_provider.dart';
 import '../models/video_timeline.dart';
 import '../platform/video_native.dart';
 import '../providers/video_timeline_provider.dart';
+import '../services/mux_upload_service.dart';
 
 class VideoPostPage extends ConsumerStatefulWidget {
   const VideoPostPage({super.key});
@@ -14,55 +20,44 @@ class VideoPostPage extends ConsumerStatefulWidget {
   ConsumerState<VideoPostPage> createState() => _VideoPostPageState();
 }
 
+enum _PostStage { idle, exporting, uploading, processing }
+
 class _VideoPostPageState extends ConsumerState<VideoPostPage> {
+  _PostStage _stage = _PostStage.idle;
   final _captionController = TextEditingController();
+  late final http.Client _httpClient;
   bool _isPrivate = false;
-  bool _isExporting = false;
+  bool _uploadFailed = false;
+  double _uploadProgress = 0;
+  File? _exportedVideoFile;
+  String? _localCoverPath;
+  String? _uploadedCoverUrl;
+  MuxUploadTicket? _currentTicket;
+  bool _uploadCompleted = false;
   String? _errorMessage;
 
   @override
+  void initState() {
+    super.initState();
+    _httpClient = http.Client();
+  }
+
+  @override
   void dispose() {
+    _httpClient.close();
     _captionController.dispose();
     super.dispose();
   }
 
   Future<void> _onPostPressed(VideoTimeline timeline) async {
-    setState(() {
-      _isExporting = true;
-      _errorMessage = null;
-    });
-
-    try {
-      final timelineJson = _buildTimelineJson(timeline);
-      final exportedPath = await VideoNative.exportEdits(
-        filePath: timeline.sourcePath,
-        timelineJson: timelineJson,
-        targetBitrateBps: 6_000_000,
-      );
-
-      final coverPath = timeline.coverImagePath;
-
-      await _uploadVideo(exportedPath, coverPath);
-
-      if (!mounted) return;
+    if (!kUseMux) {
       setState(() {
-        _isExporting = false;
+        _errorMessage = 'Video uploads are currently unavailable.';
       });
-
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Video posted!')),
-      );
-      Navigator.of(context).pop();
-    } catch (error, stackTrace) {
-      // In a production environment this would be reported to crash logging.
-      debugPrint('Failed to export video: $error\n$stackTrace');
-      if (!mounted) return;
-      setState(() {
-        _isExporting = false;
-        _errorMessage = 'Failed to export video. Please try again.';
-      });
+      return;
     }
+
+    await _startMuxPostFlow(timeline);
   }
 
   Map<String, dynamic> _buildTimelineJson(VideoTimeline timeline) {
@@ -93,15 +88,348 @@ class _VideoPostPageState extends ConsumerState<VideoPostPage> {
     return map;
   }
 
-  Future<void> _uploadVideo(String videoPath, String? coverImagePath) {
-    // TODO: Replace with upload service integration. This will hand off the
-    // exported MP4 at [videoPath] and the optional PNG cover at [coverImagePath].
-    return Future<void>.value();
+  Future<void> _startMuxPostFlow(VideoTimeline timeline) async {
+    final existing = _exportedVideoFile;
+    var hasExported = false;
+    if (existing != null && existing.existsSync()) {
+      hasExported = true;
+    } else {
+      _exportedVideoFile = null;
+    }
+
+    final needsExport = !hasExported;
+    final needsUpload = !_uploadCompleted;
+
+    setState(() {
+      _errorMessage = null;
+      _uploadFailed = false;
+      if (needsExport) {
+        _stage = _PostStage.exporting;
+      } else if (needsUpload) {
+        _stage = _PostStage.uploading;
+        _uploadProgress = 0;
+      } else {
+        _stage = _PostStage.processing;
+      }
+    });
+
+    var uploadAttempted = false;
+    var postAttempted = false;
+
+    try {
+      final videoFile = await _ensureExportedVideo(timeline);
+      final coverPath = await _ensureCoverImage(timeline);
+      final coverUrl = await _ensureCoverUpload(coverPath);
+      final ticket = await _ensureMuxTicket(videoFile);
+
+      if (!_uploadCompleted) {
+        uploadAttempted = true;
+        await _performMuxUpload(ticket, videoFile);
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _uploadCompleted = true;
+          _uploadProgress = 1.0;
+        });
+      }
+
+      postAttempted = true;
+      await _postToBackend(
+        uploadId: ticket.uploadId,
+        coverUrl: coverUrl,
+        timeline: timeline,
+      );
+
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Processing video…')),
+      );
+      Navigator.of(context).pop();
+    } catch (error, stackTrace) {
+      // In a production environment this would be reported to crash logging.
+      debugPrint('Failed to post video: $error\n$stackTrace');
+      final isTusTicket = _currentTicket?.isTus == true;
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _stage = _PostStage.idle;
+        _uploadProgress = 0;
+        _uploadFailed = uploadAttempted || postAttempted;
+        if (_uploadFailed && _currentTicket != null && !_currentTicket!.isTus && !_uploadCompleted) {
+          _currentTicket = null;
+        }
+        _errorMessage =
+            _messageForError(uploadAttempted: uploadAttempted, postAttempted: postAttempted, isTusTicket: isTusTicket);
+      });
+    }
+  }
+
+  String _messageForError({
+    required bool uploadAttempted,
+    required bool postAttempted,
+    required bool isTusTicket,
+  }) {
+    if (postAttempted) {
+      return 'Failed to create post. Please try again.';
+    }
+    if (uploadAttempted) {
+      return isTusTicket
+          ? 'Upload interrupted. Tap “Resume upload” to continue.'
+          : 'Upload failed. Tap “Retry upload” to try again.';
+    }
+    return 'Failed to prepare video. Please try again.';
+  }
+
+  Future<File> _ensureExportedVideo(VideoTimeline timeline) async {
+    final existing = _exportedVideoFile;
+    if (existing != null && await existing.exists()) {
+      return existing;
+    }
+
+    final timelineJson = _buildTimelineJson(timeline);
+    final exportedPath = await VideoNative.exportEdits(
+      filePath: timeline.sourcePath,
+      timelineJson: timelineJson,
+      targetBitrateBps: 6_000_000,
+    );
+
+    final file = File(exportedPath);
+    _exportedVideoFile = file;
+    _uploadCompleted = false;
+    return file;
+  }
+
+  Future<String> _ensureCoverImage(VideoTimeline timeline) async {
+    final cached = _localCoverPath ?? timeline.coverImagePath;
+    if (cached != null && cached.isNotEmpty) {
+      _localCoverPath = cached;
+      return cached;
+    }
+
+    final seconds = (timeline.coverTimeMs ?? 0) / 1000;
+    final coverPath = await VideoNative.generateCoverImage(
+      timeline.sourcePath,
+      seconds: seconds,
+    );
+    _localCoverPath = coverPath;
+    return coverPath;
+  }
+
+  Future<String> _ensureCoverUpload(String coverPath) async {
+    final cached = _uploadedCoverUrl;
+    if (cached != null && cached.isNotEmpty) {
+      return cached;
+    }
+    final uploaded = await _uploadCoverImage(coverPath);
+    _uploadedCoverUrl = uploaded;
+    return uploaded;
+  }
+
+  Future<String> _uploadCoverImage(String coverPath) async {
+    final file = File(coverPath);
+    if (!await file.exists()) {
+      throw FileSystemException('Cover image missing', coverPath);
+    }
+
+    final uri = _resolveBackendUri('assets/covers/presign');
+    final response = await _httpClient.post(
+      uri,
+      headers: const {'content-type': 'application/json'},
+      body: jsonEncode({
+        'filename': _basename(coverPath),
+        'content_type': 'image/png',
+      }),
+    );
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException(
+        'Failed to presign cover upload: ${response.statusCode} ${response.reasonPhrase}\n${response.body}',
+        uri: uri,
+      );
+    }
+
+    final payload = jsonDecode(response.body) as Map<String, dynamic>;
+    final uploadUrl = payload['put_url'] ?? payload['upload_url'] ?? payload['url'];
+    final assetUrl = payload['asset_url'] ?? payload['cover_url'] ?? payload['public_url'];
+    final headers = payload['headers'];
+
+    if (uploadUrl is! String || assetUrl is! String) {
+      throw const FormatException('Presign response missing upload target.');
+    }
+
+    final request = http.Request('PUT', Uri.parse(uploadUrl));
+    request.headers['content-type'] = 'image/png';
+    if (headers is Map) {
+      request.headers.addAll(headers.map(
+        (key, value) => MapEntry(key.toString(), value.toString()),
+      ));
+    }
+    request.bodyBytes = await file.readAsBytes();
+
+    final uploadResponse = await _httpClient.send(request);
+    await uploadResponse.stream.drain();
+    if (uploadResponse.statusCode < 200 || uploadResponse.statusCode >= 300) {
+      throw HttpException(
+        'Failed to upload cover: ${uploadResponse.statusCode} ${uploadResponse.reasonPhrase}',
+        uri: request.url,
+      );
+    }
+
+    return assetUrl;
+  }
+
+  Future<MuxUploadTicket> _ensureMuxTicket(File video) async {
+    final existing = _currentTicket;
+    if (existing != null) {
+      if (existing.isTus || _uploadCompleted) {
+        return existing;
+      }
+    }
+
+    final filesize = await video.length();
+    final ticket = await ref.read(muxUploadServiceProvider).createDirectUpload(
+          filename: _basename(video.path),
+          filesizeBytes: filesize,
+          contentType: 'video/mp4',
+          preferTus: true,
+        );
+    _currentTicket = ticket;
+    _uploadCompleted = false;
+    return ticket;
+  }
+
+  Future<void> _performMuxUpload(MuxUploadTicket ticket, File video) async {
+    setState(() {
+      _stage = _PostStage.uploading;
+      _uploadProgress = 0;
+    });
+
+    await ref.read(muxUploadServiceProvider).uploadVideo(
+          ticket: ticket,
+          mp4: video,
+          onProgress: (sent, total) {
+            if (!mounted) {
+              return;
+            }
+            setState(() {
+              _uploadProgress = total <= 0 ? 0 : (sent / total).clamp(0, 1);
+            });
+          },
+        );
+  }
+
+  Future<void> _postToBackend({
+    required String uploadId,
+    required String coverUrl,
+    required VideoTimeline timeline,
+  }) async {
+    setState(() {
+      _stage = _PostStage.processing;
+    });
+
+    final uri = _resolveBackendUri('posts');
+    final response = await _httpClient.post(
+      uri,
+      headers: const {'content-type': 'application/json'},
+      body: jsonEncode({
+        'mux_upload_id': uploadId,
+        'cover_url': coverUrl,
+        'caption': _captionController.text.trim(),
+        'duration_ms': _calculateDurationMs(timeline),
+        'source_device': Platform.isIOS ? 'ios' : 'android',
+      }),
+    );
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpException(
+        'Failed to create post: ${response.statusCode} ${response.reasonPhrase}\n${response.body}',
+        uri: uri,
+      );
+    }
+  }
+
+  int _calculateDurationMs(VideoTimeline timeline) {
+    final start = timeline.trimStartMs ?? 0;
+    final end = timeline.trimEndMs;
+    if (end != null && end > start) {
+      return end - start;
+    }
+    final coverTime = timeline.coverTimeMs;
+    if (coverTime != null && coverTime > start) {
+      return coverTime - start;
+    }
+    return 0;
+  }
+
+  Uri _resolveBackendUri(String path) {
+    final config = ref.read(backendConfigProvider);
+    return _ensureTrailingSlash(config.baseUri).resolve(path);
+  }
+
+  Uri _ensureTrailingSlash(Uri uri) {
+    if (uri.path.endsWith('/')) {
+      return uri;
+    }
+    final path = uri.path.isEmpty ? '/' : '${uri.path}/';
+    return uri.replace(path: path);
+  }
+
+  String _basename(String path) {
+    final normalized = path.replaceAll('\\', '/');
+    final segments = normalized.split('/');
+    return segments.isNotEmpty ? segments.last : path;
+  }
+
+  String _statusLabel() {
+    switch (_stage) {
+      case _PostStage.exporting:
+        return 'Exporting video…';
+      case _PostStage.uploading:
+        final percent = (_uploadProgress * 100).clamp(0, 100).toStringAsFixed(0);
+        return _uploadProgress > 0
+            ? 'Uploading video… $percent%'
+            : 'Uploading video…';
+      case _PostStage.processing:
+        return 'Processing video…';
+      case _PostStage.idle:
+        return '';
+    }
+  }
+
+  String _primaryButtonLabel() {
+    switch (_stage) {
+      case _PostStage.exporting:
+        return 'Exporting…';
+      case _PostStage.uploading:
+        return 'Uploading…';
+      case _PostStage.processing:
+        return 'Processing…';
+      case _PostStage.idle:
+        if (_uploadFailed) {
+          if (_uploadCompleted) {
+            return 'Retry';
+          }
+          return _currentTicket?.isTus == true ? 'Resume upload' : 'Retry upload';
+        }
+        return 'Post';
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final timeline = ref.watch(videoTimelineProvider);
+    final isBusy =
+        _stage == _PostStage.exporting || _stage == _PostStage.uploading || _stage == _PostStage.processing;
+    final double? progressValue = _stage == _PostStage.uploading
+        ? (_uploadProgress.clamp(0.0, 1.0) as double)
+        : null;
+    final buttonLabel = _primaryButtonLabel();
+    final VoidCallback? buttonOnPressed =
+        timeline == null || isBusy ? null : () => _onPostPressed(timeline);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Post video')),
@@ -113,12 +441,12 @@ class _VideoPostPageState extends ConsumerState<VideoPostPage> {
             TextField(
               controller: _captionController,
               decoration: const InputDecoration(labelText: 'Caption'),
-              enabled: !_isExporting,
+              enabled: !isBusy,
             ),
             SwitchListTile(
               value: _isPrivate,
               title: const Text('Private'),
-              onChanged: _isExporting
+              onChanged: isBusy
                   ? null
                   : (value) {
                       setState(() {
@@ -126,11 +454,14 @@ class _VideoPostPageState extends ConsumerState<VideoPostPage> {
                       });
                     },
             ),
-            if (_isExporting) ...[
+            if (isBusy) ...[
               const SizedBox(height: 16),
-              const LinearProgressIndicator(),
+              LinearProgressIndicator(value: progressValue),
               const SizedBox(height: 8),
-              const Text('Exporting video...'),
+              Text(
+                _statusLabel(),
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
             ],
             if (_errorMessage != null) ...[
               const SizedBox(height: 16),
@@ -146,10 +477,8 @@ class _VideoPostPageState extends ConsumerState<VideoPostPage> {
             SizedBox(
               width: double.infinity,
               child: ElevatedButton(
-                onPressed: timeline == null || _isExporting
-                    ? null
-                    : () => _onPostPressed(timeline),
-                child: const Text('Post'),
+                onPressed: buttonOnPressed,
+                child: Text(buttonLabel),
               ),
             ),
           ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   flutter_cache_manager: ^3.3.1
   connectivity_plus: ^7.0.0
   http: ^1.2.2
+  tus_client: ^2.0.0
   video_compress: ^3.1.3
   mime: ^1.0.6
 


### PR DESCRIPTION
## Summary
- add a lightweight Node/Express backend configured with Mux client dependencies
- expose endpoints to mint direct upload URLs, inspect upload status, and handle Mux webhooks
- include webhook signature verification and permissive CORS setup for mobile clients

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68d5c5ec4f588328b754a5ac09a31d17