### PR TITLE
Add video card widget and feed teaser

### DIFF
--- a/lib/features/feed/presentation/feed_screen.dart
+++ b/lib/features/feed/presentation/feed_screen.dart
@@ -10,6 +10,7 @@ import '../../feed/data/feed_ranking_algorithm.dart';
 import '../../feed/domain/feed_content.dart';
 import 'widgets/feed_card.dart';
 import 'widgets/feed_comments_sheet.dart';
+import 'widgets/simple_video_feed_item.dart';
 
 class FeedScreen extends ConsumerStatefulWidget {
   const FeedScreen({super.key});
@@ -83,9 +84,21 @@ class _FeedScreenState extends ConsumerState<FeedScreen> {
                 setState(() => _activePageIndex = index);
               },
               itemBuilder: (context, index) {
-                final loopIndex = items.isNotEmpty ? index % items.length : 0;
-                final content = items[loopIndex];
+                final cycleLength = items.length + 1;
+                final loopIndex = index % cycleLength;
                 final isActive = index == _activePageIndex;
+
+                if (loopIndex == 0) {
+                  return Padding(
+                    padding: const EdgeInsets.fromLTRB(20, 12, 20, 12),
+                    child: SimpleVideoFeedItem(
+                      isActive: isActive,
+                    ),
+                  );
+                }
+
+                final contentIndex = (loopIndex - 1) % items.length;
+                final content = items[contentIndex];
                 final isLiked = user?.likedContentIds.contains(content.id) ?? false;
                 final isFollowingCreator = _isFollowingPoster(user, content);
 

--- a/lib/features/feed/presentation/widgets/simple_video_feed_item.dart
+++ b/lib/features/feed/presentation/widgets/simple_video_feed_item.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+import '../../../video/widgets/video_card.dart';
+
+class SimpleVideoFeedItem extends StatelessWidget {
+  const SimpleVideoFeedItem({
+    super.key,
+    required this.isActive,
+  });
+
+  final bool isActive;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(28),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface,
+        ),
+        child: VideoCard(
+          thumbnailUrl:
+              'https://storage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg',
+          playbackUrl:
+              'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.m3u8',
+          caption: 'See how we are investing in Montana\'s outdoor economy.',
+          isActive: isActive,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/video/widgets/video_card.dart
+++ b/lib/features/video/widgets/video_card.dart
@@ -1,0 +1,202 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+
+class VideoCard extends StatefulWidget {
+  const VideoCard({
+    super.key,
+    required this.thumbnailUrl,
+    required this.playbackUrl,
+    required this.caption,
+    this.isActive = true,
+  });
+
+  final String thumbnailUrl;
+  final String playbackUrl;
+  final String caption;
+  final bool isActive;
+
+  @override
+  State<VideoCard> createState() => _VideoCardState();
+}
+
+class _VideoCardState extends State<VideoCard>
+    with AutomaticKeepAliveClientMixin<VideoCard> {
+  VideoPlayerController? _controller;
+  bool _showPoster = true;
+  bool _isBuffering = true;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_initializeController());
+  }
+
+  @override
+  void didUpdateWidget(covariant VideoCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.playbackUrl != oldWidget.playbackUrl) {
+      unawaited(_initializeController());
+    }
+
+    final controller = _controller;
+    if (controller != null && widget.isActive != oldWidget.isActive) {
+      if (widget.isActive) {
+        if (controller.value.isInitialized) {
+          controller.play();
+        }
+      } else {
+        controller.pause();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    final controller = _controller;
+    controller?.removeListener(_handleControllerUpdate);
+    controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    final controller = _controller;
+    final isInitialized = controller?.value.isInitialized ?? false;
+    final aspectRatio = isInitialized ? controller!.value.aspectRatio : 9 / 16;
+
+    return AspectRatio(
+      aspectRatio: aspectRatio,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          if (isInitialized)
+            VideoPlayer(controller!)
+          else
+            const ColoredBox(color: Colors.black),
+          AnimatedOpacity(
+            opacity: _showPoster ? 1 : 0,
+            duration: const Duration(milliseconds: 240),
+            curve: Curves.easeOutCubic,
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                Image.network(
+                  widget.thumbnailUrl,
+                  fit: BoxFit.cover,
+                  errorBuilder: (context, _, __) => const ColoredBox(
+                    color: Colors.black,
+                  ),
+                ),
+                if (_isBuffering)
+                  const Center(
+                    child: SizedBox(
+                      height: 40,
+                      width: 40,
+                      child: CircularProgressIndicator.adaptive(),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.bottomCenter,
+                  end: Alignment.topCenter,
+                  colors: [
+                    Colors.black.withValues(alpha: 0.8),
+                    Colors.black.withValues(alpha: 0.0),
+                  ],
+                ),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
+                child: Text(
+                  widget.caption,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                      ) ??
+                      const TextStyle(
+                        color: Colors.white,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _initializeController() async {
+    final oldController = _controller;
+    oldController?.removeListener(_handleControllerUpdate);
+    await oldController?.dispose();
+
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _controller = null;
+      _showPoster = true;
+      _isBuffering = true;
+    });
+
+    final controller = VideoPlayerController.networkUrl(
+      Uri.parse(widget.playbackUrl),
+      videoPlayerOptions: const VideoPlayerOptions(mixWithOthers: true),
+    );
+
+    await controller.initialize();
+    await controller.setVolume(0);
+    await controller.setLooping(true);
+    controller.addListener(_handleControllerUpdate);
+
+    if (!mounted) {
+      await controller.dispose();
+      return;
+    }
+
+    setState(() {
+      _controller = controller;
+      _updatePosterState(controller.value);
+    });
+
+    if (widget.isActive) {
+      await controller.play();
+    }
+  }
+
+  void _handleControllerUpdate() {
+    final controller = _controller;
+    if (controller == null || !mounted) {
+      return;
+    }
+    _updatePosterState(controller.value);
+  }
+
+  void _updatePosterState(VideoPlayerValue value) {
+    final shouldShowPoster = !value.isInitialized || value.isBuffering;
+    final isBuffering = value.isBuffering;
+    if (shouldShowPoster != _showPoster || isBuffering != _isBuffering) {
+      setState(() {
+        _showPoster = shouldShowPoster;
+        _isBuffering = isBuffering;
+      });
+    }
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+}


### PR DESCRIPTION
## Summary
- add a reusable video card widget that initializes an HLS controller, shows a poster while buffering, and auto-plays when active
- surface a simple promotional feed item that uses the new video card ahead of the personalized feed content

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d61b7b8a108328986405c8af861dbc