### PR TITLE
Implement just-in-time media permission request

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- API 33+: granular media permissions -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <!-- API 32 and below: legacy external storage access -->
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />

--- a/lib/features/create/presentation/media_picker_screen.dart
+++ b/lib/features/create/presentation/media_picker_screen.dart
@@ -33,6 +33,13 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
   static const _pageSize = 80;
   static const double _defaultVideoAspectRatio = 9 / 16;
   static const double _defaultImageAspectRatio = 4 / 5;
+  static const PermissionRequestOption _permissionRequestOption =
+      PermissionRequestOption(
+    androidPermission: AndroidPermission(
+      type: RequestType.common,
+      mediaLocation: false,
+    ),
+  );
 
   final ScrollController _gridController = ScrollController();
 
@@ -44,6 +51,7 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
 
   bool _initializing = true;
   bool _permissionDenied = false;
+  PermissionState? _permissionState;
   bool _loadingMore = false;
   bool _hasMore = true;
   int _currentPage = 0;
@@ -71,16 +79,39 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
     super.dispose();
   }
 
+  bool _permissionHasAccess(PermissionState state) {
+    return state == PermissionState.authorized ||
+        state == PermissionState.limited;
+  }
+
   Future<void> _initGallery() async {
-    final permission = await PhotoManager.requestPermissionExtend();
-    if (!permission.hasAccess) {
-      if (!mounted) return;
+    final permission = await PhotoManager.getPermissionState(
+      requestOption: _permissionRequestOption,
+    );
+    if (!mounted) return;
+
+    if (!_permissionHasAccess(permission)) {
       setState(() {
         _permissionDenied = true;
+        _permissionState = permission;
         _initializing = false;
       });
       return;
     }
+
+    setState(() {
+      _permissionState = permission;
+    });
+
+    await _loadGalleryAssets();
+  }
+
+  Future<void> _loadGalleryAssets() async {
+    if (!mounted) return;
+    setState(() {
+      _initializing = true;
+      _permissionDenied = false;
+    });
 
     final paths = await PhotoManager.getAssetPathList(
       type: RequestType.common,
@@ -129,6 +160,35 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
     if (first != null) {
       await _prepareSelection(first);
     }
+  }
+
+  Future<void> _requestPermission() async {
+    final permission = await PhotoManager.requestPermissionExtend(
+      requestOption: _permissionRequestOption,
+    );
+    if (!mounted) return;
+
+    if (_permissionHasAccess(permission)) {
+      setState(() {
+        _permissionState = permission;
+      });
+      await _loadGalleryAssets();
+      return;
+    }
+
+    setState(() {
+      _permissionDenied = true;
+      _permissionState = permission;
+    });
+  }
+
+  bool get _shouldShowSettingsButton {
+    final permission = _permissionState;
+    if (permission == null) {
+      return false;
+    }
+    return permission == PermissionState.denied ||
+        permission == PermissionState.restricted;
   }
 
   void _handleScroll() {
@@ -368,6 +428,8 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
 
   Future<void> _openSettings() async {
     await PhotoManager.openSetting();
+    if (!mounted) return;
+    await _initGallery();
   }
 
   @override
@@ -381,7 +443,11 @@ class _MediaPickerScreenState extends State<MediaPickerScreen> {
                 child: CircularProgressIndicator(),
               )
             : _permissionDenied
-                ? _PermissionView(onOpenSettings: _openSettings)
+                ? _PermissionView(
+                    onRequestPermission: _requestPermission,
+                    onOpenSettings: _openSettings,
+                    showSettings: _shouldShowSettingsButton,
+                  )
                 : _visibleAssets.isEmpty
                     ? _EmptyGalleryView(
                         onClose: () => Navigator.of(context).maybePop())
@@ -773,9 +839,15 @@ class _AssetThumbnail extends StatelessWidget {
 }
 
 class _PermissionView extends StatelessWidget {
-  const _PermissionView({required this.onOpenSettings});
+  const _PermissionView({
+    required this.onRequestPermission,
+    required this.onOpenSettings,
+    required this.showSettings,
+  });
 
+  final VoidCallback onRequestPermission;
   final VoidCallback onOpenSettings;
+  final bool showSettings;
 
   @override
   Widget build(BuildContext context) {
@@ -802,11 +874,27 @@ class _PermissionView extends StatelessWidget {
             style: TextStyle(color: Colors.white70),
             textAlign: TextAlign.center,
           ),
+          if (showSettings)
+            const Padding(
+              padding: EdgeInsets.only(top: 8),
+              child: Text(
+                'If you previously denied access, enable it from system settings.',
+                style: TextStyle(color: Colors.white54),
+                textAlign: TextAlign.center,
+              ),
+            ),
           const SizedBox(height: 24),
           FilledButton(
-            onPressed: onOpenSettings,
-            child: const Text('Open settings'),
+            onPressed: onRequestPermission,
+            child: const Text('Allow access'),
           ),
+          if (showSettings) ...[
+            const SizedBox(height: 12),
+            OutlinedButton(
+              onPressed: onOpenSettings,
+              child: const Text('Open settings'),
+            ),
+          ],
           const SizedBox(height: 12),
           TextButton(
             onPressed: () => Navigator.of(context).maybePop(),


### PR DESCRIPTION
## Summary
- document the Android media read permissions for API 33+ and legacy devices
- add a just-in-time permission request flow in the media picker that refreshes after granting access or returning from settings

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d61cc749208328a81f949667d64686