### PR TITLE
Handle video permission plugin failures gracefully

### DIFF
--- a/lib/features/video/views/video_picker_page.dart
+++ b/lib/features/video/views/video_picker_page.dart
@@ -25,7 +25,21 @@ class VideoPickerPage extends ConsumerWidget {
         child: ElevatedButton(
           onPressed: () async {
             final permissionService = ref.read(videoPermissionServiceProvider);
-            final permissionResult = await permissionService.ensureGranted();
+            VideoPermissionResult permissionResult;
+            try {
+              permissionResult = await permissionService.ensureGranted();
+            } on VideoPermissionException catch (error) {
+              if (!context.mounted) {
+                return;
+              }
+              final message = error.message.isNotEmpty
+                  ? error.message
+                  : 'Unable to verify video permissions. Please try again later.';
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text(message)),
+              );
+              return;
+            }
             if (!permissionResult.granted) {
               if (!context.mounted) {
                 return;


### PR DESCRIPTION
## Summary
- propagate plugin exceptions when checking or requesting video permissions and surface them as a dedicated VideoPermissionException
- ensure the video picker view shows an error snackbar when permission validation fails instead of attempting to launch the picker

## Testing
- Not run (Flutter SDK is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dc52a5592c8328929fb53b5e098a73