### PR TITLE
Add Glide module configuration for HEVC thumbnails

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -3,6 +3,7 @@ import kotlin.math.max
 plugins {
     id("com.android.application")
     id("kotlin-android")
+    id("kotlin-kapt")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
@@ -50,4 +51,5 @@ dependencies {
     implementation("androidx.media3:media3-exoplayer:1.5.1")
     implementation("androidx.media3:media3-transformer:1.5.1")
     implementation("androidx.media3:media3-effect:1.5.1")
+    kapt("com.github.bumptech.glide:compiler:4.16.0")
 }

--- a/android/app/src/main/kotlin/com/example/coalition_mobile_app/CoalitionGlideModule.kt
+++ b/android/app/src/main/kotlin/com/example/coalition_mobile_app/CoalitionGlideModule.kt
@@ -1,0 +1,7 @@
+package com.example.coalition_mobile_app
+
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.module.AppGlideModule
+
+@GlideModule
+class CoalitionGlideModule : AppGlideModule()


### PR DESCRIPTION
## Summary
- enable the Kotlin KAPT plugin and add Glide's annotation processor so GeneratedAppGlideModule is created
- add a minimal AppGlideModule implementation to register the picker LibraryGlideModule

## Testing
- not run (Flutter tooling is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68dd4b6809d88328a2bae15c64c51553