### PR TITLE
Improve Android video thumbnail handling

### DIFF
--- a/android/app/src/main/kotlin/com/example/coalition_mobile_app/FrameExtractionSupport.kt
+++ b/android/app/src/main/kotlin/com/example/coalition_mobile_app/FrameExtractionSupport.kt
@@ -1,0 +1,180 @@
+package com.example.coalition_mobile_app
+
+import android.content.Context
+import android.graphics.PixelFormat
+import android.media.Image
+import android.media.ImageReader
+import android.media.MediaCodec
+import android.view.Surface
+import androidx.media3.common.C
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.common.util.Util
+import androidx.media3.decoder.DecoderInputBuffer
+import androidx.media3.transformer.Codec
+import androidx.media3.transformer.Transformer
+import com.google.common.collect.ImmutableList
+import java.nio.ByteBuffer
+import java.util.concurrent.ConcurrentLinkedQueue
+
+@UnstableApi
+object FrameExtractionSupport {
+    interface Listener {
+        fun onImageAvailable(image: Image)
+    }
+
+    fun buildFrameExtractorTransformer(
+        context: Context,
+        listener: Listener,
+    ): Transformer {
+        return Transformer.Builder(context)
+            .experimentalSetTrimOptimizationEnabled(false)
+            .setEncoderFactory(ImageReaderEncoder.Factory(listener))
+            .setMaxDelayBetweenMuxerSamplesMs(C.TIME_UNSET)
+            .setMuxerFactory(
+                NoOpMuxer.Factory(
+                    ImmutableList.of(MimeTypes.AUDIO_AAC),
+                    ImmutableList.of(MimeTypes.VIDEO_H264),
+                ),
+            )
+            .setAudioMimeType(MimeTypes.AUDIO_AAC)
+            .setVideoMimeType(MimeTypes.VIDEO_H264)
+            .experimentalSetMaxFramesInEncoder(1)
+            .build()
+    }
+
+    private class ImageReaderEncoder(
+        private val configurationFormat: Format,
+        listener: Listener,
+    ) : Codec {
+        class Factory(private val listener: Listener) : Codec.EncoderFactory {
+            override fun createForAudioEncoding(format: Format): Codec {
+                throw UnsupportedOperationException()
+            }
+
+            override fun createForVideoEncoding(format: Format): Codec {
+                return ImageReaderEncoder(format, listener)
+            }
+        }
+
+        private val imageReader = ImageReader.newInstance(
+            configurationFormat.width,
+            configurationFormat.height,
+            PixelFormat.RGBA_8888,
+            /* maxImages = */ 1,
+        )
+        private val processedImageTimestampsNs = ConcurrentLinkedQueue<Long>()
+        private val outputBufferInfo = MediaCodec.BufferInfo()
+        private var hasOutputBuffer = false
+        private var inputStreamEnded = false
+
+        init {
+            imageReader.setOnImageAvailableListener(
+                { reader ->
+                    val image = reader.acquireNextImage()
+                    if (image != null) {
+                        image.use {
+                            processedImageTimestampsNs.add(it.timestamp)
+                            listener.onImageAvailable(it)
+                        }
+                    }
+                },
+                Util.createHandlerForCurrentOrMainLooper(),
+            )
+        }
+
+        override fun getName(): String = NAME
+
+        override fun getConfigurationFormat(): Format = configurationFormat
+
+        override fun getInputSurface(): Surface = imageReader.surface
+
+        override fun maybeDequeueInputBuffer(inputBuffer: DecoderInputBuffer): Boolean {
+            throw UnsupportedOperationException()
+        }
+
+        override fun queueInputBuffer(inputBuffer: DecoderInputBuffer) {
+            throw UnsupportedOperationException()
+        }
+
+        override fun signalEndOfInputStream() {
+            inputStreamEnded = true
+        }
+
+        override fun getOutputFormat(): Format = configurationFormat
+
+        override fun getOutputBuffer(): ByteBuffer? =
+            if (maybeGenerateOutputBuffer()) EMPTY_BUFFER else null
+
+        override fun getOutputBufferInfo(): MediaCodec.BufferInfo? =
+            if (maybeGenerateOutputBuffer()) outputBufferInfo else null
+
+        override fun isEnded(): Boolean = inputStreamEnded && processedImageTimestampsNs.isEmpty()
+
+        override fun releaseOutputBuffer(render: Boolean) {
+            releaseOutputBuffer()
+        }
+
+        override fun releaseOutputBuffer(renderPresentationTimeUs: Long) {
+            releaseOutputBuffer()
+        }
+
+        private fun releaseOutputBuffer() {
+            hasOutputBuffer = false
+        }
+
+        override fun release() {
+            imageReader.close()
+        }
+
+        private fun maybeGenerateOutputBuffer(): Boolean {
+            if (hasOutputBuffer) {
+                return true
+            }
+            val timeNs = processedImageTimestampsNs.poll() ?: return false
+            hasOutputBuffer = true
+            outputBufferInfo.presentationTimeUs = timeNs / 1_000
+            outputBufferInfo.size = 0
+            outputBufferInfo.offset = 0
+            outputBufferInfo.flags = 0
+            return true
+        }
+
+        companion object {
+            private const val NAME = "ImageReaderEncoder"
+            private val EMPTY_BUFFER: ByteBuffer = ByteBuffer.allocateDirect(0)
+        }
+    }
+
+    private class NoOpMuxer : androidx.media3.muxer.Muxer {
+        class Factory(
+            private val audioMimeTypes: ImmutableList<String>,
+            private val videoMimeTypes: ImmutableList<String>,
+        ) : androidx.media3.muxer.Muxer.Factory {
+            override fun create(path: String): androidx.media3.muxer.Muxer = NoOpMuxer()
+
+            override fun getSupportedSampleMimeTypes(trackType: Int): ImmutableList<String> {
+                return when (trackType) {
+                    C.TRACK_TYPE_AUDIO -> audioMimeTypes
+                    C.TRACK_TYPE_VIDEO -> videoMimeTypes
+                    else -> ImmutableList.of()
+                }
+            }
+        }
+
+        override fun addTrack(format: Format): androidx.media3.muxer.Muxer.TrackToken {
+            return object : androidx.media3.muxer.Muxer.TrackToken {}
+        }
+
+        override fun writeSampleData(
+            trackToken: androidx.media3.muxer.Muxer.TrackToken,
+            data: ByteBuffer,
+            bufferInfo: MediaCodec.BufferInfo,
+        ) = Unit
+
+        override fun addMetadataEntry(metadataEntry: androidx.media3.common.Metadata.Entry) = Unit
+
+        override fun close() = Unit
+    }
+}

--- a/lib/features/video/platform/video_native.dart
+++ b/lib/features/video/platform/video_native.dart
@@ -8,6 +8,8 @@ abstract class VideoNativeBridge {
 
   Future<String> generateCoverImage(String filePath, {required double seconds});
 
+  Future<void> persistUriPermission(String uri);
+
   Future<String> exportEdits({
     required String filePath,
     required Map<String, dynamic> timelineJson,
@@ -34,6 +36,13 @@ class VideoNative implements VideoNativeBridge {
       'seconds': seconds,
     });
     return result ?? '';
+  }
+
+  @override
+  Future<void> persistUriPermission(String uri) async {
+    await _ch.invokeMethod<void>('persistUriPermission', {
+      'uri': uri,
+    });
   }
 
   @override

--- a/lib/features/video/views/video_picker_page.dart
+++ b/lib/features/video/views/video_picker_page.dart
@@ -14,6 +14,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:wechat_assets_picker/wechat_assets_picker.dart';
 import 'package:wechat_camera_picker/wechat_camera_picker.dart';
 
+import '../platform/video_native.dart';
 import '../services/video_permission_service.dart';
 
 class VideoPickerPage extends ConsumerStatefulWidget {
@@ -246,6 +247,7 @@ class _VideoPickerPageState extends ConsumerState<VideoPickerPage> {
     if (assets == null || assets.isEmpty) {
       return null;
     }
+    await _persistAssetPermission(assets.first);
     return assets.first.file;
   }
 
@@ -289,6 +291,21 @@ class _VideoPickerPageState extends ConsumerState<VideoPickerPage> {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(message)),
     );
+  }
+
+  Future<void> _persistAssetPermission(AssetEntity asset) async {
+    if (!Platform.isAndroid) {
+      return;
+    }
+    try {
+      final uri = await asset.getMediaUrl();
+      if (uri == null || !uri.startsWith('content://')) {
+        return;
+      }
+      await ref.read(videoNativeProvider).persistUriPermission(uri);
+    } catch (error, stackTrace) {
+      debugPrint('Failed to persist URI permission for asset: $error\n$stackTrace');
+    }
   }
 }
 

--- a/test/video_editor_page_test.dart
+++ b/test/video_editor_page_test.dart
@@ -24,6 +24,9 @@ class _StubVideoNative extends VideoNativeBridge {
   Future<void> cancelExport() async {}
 
   @override
+  Future<void> persistUriPermission(String uri) async {}
+
+  @override
   Future<String> exportEdits({
     required String filePath,
     required Map<String, dynamic> timelineJson,

--- a/test/video_post_page_test.dart
+++ b/test/video_post_page_test.dart
@@ -117,6 +117,9 @@ class _StubVideoNative extends VideoNativeBridge {
 
   @override
   Future<void> cancelExport() async {}
+
+  @override
+  Future<void> persistUriPermission(String uri) async {}
 }
 
 void main() {


### PR DESCRIPTION
## Summary
- add missing `persistUriPermission` overrides to the VideoNative test stubs so they satisfy the updated bridge contract

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd5440219883289ecb50a3ca88cf6d