### PR TITLE
Improve video frame extraction reliability

### DIFF
--- a/android/app/src/main/kotlin/com/example/coalition_mobile_app/CoalitionGlideModule.kt
+++ b/android/app/src/main/kotlin/com/example/coalition_mobile_app/CoalitionGlideModule.kt
@@ -1,7 +1,14 @@
 package com.example.coalition_mobile_app
 
+import android.content.Context
+import com.bumptech.glide.Glide
 import com.bumptech.glide.annotation.GlideModule
 import com.bumptech.glide.module.AppGlideModule
+import com.bumptech.glide.Registry
 
 @GlideModule
-class CoalitionGlideModule : AppGlideModule()
+class CoalitionGlideModule : AppGlideModule() {
+    override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
+        registry.registerCoalitionVideoDecoders(context, glide)
+    }
+}

--- a/android/app/src/main/kotlin/com/example/coalition_mobile_app/VideoFileUtils.kt
+++ b/android/app/src/main/kotlin/com/example/coalition_mobile_app/VideoFileUtils.kt
@@ -1,0 +1,12 @@
+package com.example.coalition_mobile_app
+
+import android.content.Context
+import java.io.File
+
+internal fun createVideoTempFile(context: Context, prefix: String, suffix: String): File {
+    val directory = File(context.cacheDir, "video_native")
+    if (!directory.exists()) {
+        directory.mkdirs()
+    }
+    return File.createTempFile(prefix, suffix, directory)
+}

--- a/android/app/src/main/kotlin/com/example/coalition_mobile_app/VideoFrameExtractor.kt
+++ b/android/app/src/main/kotlin/com/example/coalition_mobile_app/VideoFrameExtractor.kt
@@ -1,0 +1,436 @@
+package com.example.coalition_mobile_app
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.media.Image
+import android.media.MediaMetadataRetriever
+import android.media.ThumbnailUtils
+import android.net.Uri
+import android.os.Build
+import android.os.CancellationSignal
+import android.os.ParcelFileDescriptor
+import android.provider.MediaStore
+import android.util.Size
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.transformer.TransformationResult
+import androidx.media3.transformer.Transformer
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.IOException
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.math.max
+
+@OptIn(UnstableApi::class)
+internal class VideoFrameExtractor private constructor(private val appContext: Context) {
+
+    fun extractFrameFromUri(
+        uri: Uri,
+        frameTimeUs: Long,
+        targetSizePx: Int = DEFAULT_TARGET_SIZE,
+    ): Bitmap {
+        return extractFrame(DataSource.UriSource(uri), frameTimeUs, targetSizePx)
+    }
+
+    fun extractFrameFromPath(
+        path: String,
+        frameTimeUs: Long,
+        targetSizePx: Int = DEFAULT_TARGET_SIZE,
+    ): Bitmap {
+        return extractFrame(DataSource.PathSource(path), frameTimeUs, targetSizePx)
+    }
+
+    fun extractFrameFromFileDescriptor(
+        descriptor: ParcelFileDescriptor,
+        frameTimeUs: Long,
+        targetSizePx: Int = DEFAULT_TARGET_SIZE,
+    ): Bitmap {
+        return extractFrame(DataSource.DescriptorSource(descriptor), frameTimeUs, targetSizePx)
+    }
+
+    private fun extractFrame(
+        dataSource: DataSource,
+        requestedFrameTimeUs: Long,
+        targetSizePx: Int,
+    ): Bitmap {
+        val sanitizedFrameTimeUs = sanitizeFrameTime(requestedFrameTimeUs)
+        val retrieverResult = try {
+            runWithTimeout(DECODE_TIMEOUT_MS) {
+                attemptWithMediaMetadataRetriever(dataSource, sanitizedFrameTimeUs)
+            }
+        } catch (timeout: TimeoutException) {
+            android.util.Log.w(TAG, "MediaMetadataRetriever timed out for $dataSource", timeout)
+            null
+        } catch (error: Throwable) {
+            android.util.Log.w(TAG, "MediaMetadataRetriever failed for $dataSource", error)
+            null
+        }
+
+        if (retrieverResult != null) {
+            return maybeScale(retrieverResult, targetSizePx)
+        }
+
+        val thumbnailResult = try {
+            attemptWithThumbnailUtils(dataSource)
+        } catch (error: Throwable) {
+            android.util.Log.w(TAG, "ThumbnailUtils fallback failed for $dataSource", error)
+            null
+        }
+
+        if (thumbnailResult != null) {
+            return maybeScale(thumbnailResult, targetSizePx)
+        }
+
+        val media3Result = try {
+            attemptWithMedia3(dataSource, sanitizedFrameTimeUs)
+        } catch (error: Throwable) {
+            android.util.Log.e(TAG, "Media3 fallback failed for $dataSource", error)
+            null
+        }
+
+        if (media3Result != null) {
+            return maybeScale(media3Result, targetSizePx)
+        }
+
+        throw IOException("Unable to extract frame for $dataSource")
+    }
+
+    private fun attemptWithMediaMetadataRetriever(
+        dataSource: DataSource,
+        frameTimeUs: Long,
+    ): Bitmap? {
+        var retriever: MediaMetadataRetriever? = null
+        var parcelFileDescriptor: ParcelFileDescriptor? = null
+        var tempFile: File? = null
+        return try {
+            retriever = MediaMetadataRetriever()
+            when (dataSource) {
+                is DataSource.UriSource -> {
+                    val result = openUriForRetriever(dataSource.uri)
+                    parcelFileDescriptor = result.first
+                    tempFile = result.second
+                    when {
+                        parcelFileDescriptor != null -> retriever.setDataSource(parcelFileDescriptor.fileDescriptor)
+                        tempFile != null -> retriever.setDataSource(tempFile.absolutePath)
+                        else -> retriever.setDataSource(appContext, dataSource.uri)
+                    }
+                }
+                is DataSource.PathSource -> {
+                    retriever.setDataSource(dataSource.path)
+                }
+                is DataSource.DescriptorSource -> {
+                    parcelFileDescriptor = dataSource.duplicate()
+                    retriever.setDataSource(parcelFileDescriptor!!.fileDescriptor)
+                }
+            }
+            retriever.getFrameAtTime(frameTimeUs, MediaMetadataRetriever.OPTION_CLOSEST)
+        } catch (error: Throwable) {
+            android.util.Log.w(TAG, "MediaMetadataRetriever threw for $dataSource", error)
+            null
+        } finally {
+            retriever?.release()
+            try {
+                parcelFileDescriptor?.close()
+            } catch (_: Throwable) {
+            }
+            tempFile?.let {
+                if (!it.delete()) {
+                    android.util.Log.d(TAG, "Temporary copy ${it.absolutePath} could not be deleted immediately")
+                }
+            }
+        }
+    }
+
+    private fun attemptWithThumbnailUtils(dataSource: DataSource): Bitmap? {
+        val prepared = dataSource.prepareLocalCopy(appContext)
+        val cleanup = prepared.cleanup
+        var legacyTemp: File? = null
+        try {
+            val uri = prepared.uri
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                val signal = CancellationSignal()
+                ThumbnailUtils.createVideoThumbnail(appContext.contentResolver, uri, Size(DEFAULT_TARGET_SIZE, DEFAULT_TARGET_SIZE), signal)
+            } else {
+                val path = when (uri.scheme?.lowercase()) {
+                    "content" -> {
+                        legacyTemp = copyUriToTempFile(uri)
+                        legacyTemp?.absolutePath
+                    }
+                    "file" -> uri.path
+                    else -> uri.path
+                }
+                if (path != null) {
+                    ThumbnailUtils.createVideoThumbnail(path, MediaStore.Images.Thumbnails.MINI_KIND)
+                } else {
+                    null
+                }
+            }
+        } finally {
+            legacyTemp?.let {
+                if (!it.delete()) {
+                    android.util.Log.d(TAG, "Temporary legacy thumbnail ${it.absolutePath} could not be deleted")
+                }
+            }
+            cleanup?.invoke()
+        }
+    }
+
+    private fun attemptWithMedia3(
+        dataSource: DataSource,
+        frameTimeUs: Long,
+    ): Bitmap? {
+        val prepared = dataSource.prepareLocalCopy(appContext)
+        val cleanup = prepared.cleanup
+        val latch = CountDownLatch(1)
+        val result = AtomicReference<Bitmap?>()
+        val failure = AtomicReference<Throwable?>()
+        val finished = AtomicBoolean(false)
+
+        try {
+            val transformer = FrameExtractionSupport.buildFrameExtractorTransformer(
+                appContext,
+                object : FrameExtractionSupport.Listener {
+                    override fun onImageAvailable(image: Image) {
+                        try {
+                            result.compareAndSet(null, imageToBitmap(image))
+                        } catch (error: Throwable) {
+                            failure.compareAndSet(null, error)
+                        } finally {
+                            if (finished.compareAndSet(false, true)) {
+                                latch.countDown()
+                            }
+                        }
+                    }
+                },
+            )
+
+            transformer.addListener(
+                object : Transformer.Listener {
+                    override fun onTransformationError(mediaItem: MediaItem, exception: Exception) {
+                        failure.compareAndSet(null, exception)
+                        if (finished.compareAndSet(false, true)) {
+                            latch.countDown()
+                        }
+                    }
+
+                    override fun onTransformationCompleted(
+                        mediaItem: MediaItem,
+                        transformationResult: TransformationResult,
+                    ) {
+                        if (result.get() == null) {
+                            failure.compareAndSet(null, IOException("No frame extracted"))
+                        }
+                        if (finished.compareAndSet(false, true)) {
+                            latch.countDown()
+                        }
+                    }
+                },
+            )
+
+            val clipStartMs = max(0L, frameTimeUs / 1000)
+            val clipEndMs = clipStartMs + 1_000L
+            val mediaItemBuilder = MediaItem.Builder().setUri(prepared.uri)
+            mediaItemBuilder.setClippingConfiguration(
+                MediaItem.ClippingConfiguration.Builder()
+                    .setStartPositionMs(clipStartMs)
+                    .setEndPositionMs(clipEndMs)
+                    .build(),
+            )
+            val edited = androidx.media3.transformer.EditedMediaItem.Builder(mediaItemBuilder.build())
+                .setRemoveAudio(true)
+                .build()
+
+            val output = createVideoTempFile(appContext, "frame_extract_", ".tmp")
+            try {
+                transformer.start(edited, output.absolutePath)
+                if (!latch.await(5, TimeUnit.SECONDS)) {
+                    failure.compareAndSet(null, IOException("Timed out waiting for frame extraction"))
+                    finished.compareAndSet(false, true)
+                }
+            } finally {
+                transformer.cancel()
+                if (!output.delete()) {
+                    android.util.Log.d(TAG, "Temporary transformer output ${output.absolutePath} could not be deleted")
+                }
+            }
+        } catch (interrupted: InterruptedException) {
+            Thread.currentThread().interrupt()
+            failure.compareAndSet(null, interrupted)
+        } catch (error: Throwable) {
+            failure.compareAndSet(null, error)
+        } finally {
+            cleanup?.invoke()
+        }
+
+        failure.get()?.let { throw it }
+        return result.get()
+    }
+
+    private fun openUriForRetriever(uri: Uri): Pair<ParcelFileDescriptor?, File?> {
+        return try {
+            val pfd = appContext.contentResolver.openFileDescriptor(uri, "r")
+            Pair(pfd, null)
+        } catch (security: SecurityException) {
+            android.util.Log.w(TAG, "openFileDescriptor security exception for $uri", security)
+            Pair(null, copyUriToTempFile(uri))
+        } catch (ioe: IOException) {
+            android.util.Log.w(TAG, "openFileDescriptor IO exception for $uri", ioe)
+            Pair(null, copyUriToTempFile(uri))
+        } catch (error: Throwable) {
+            android.util.Log.w(TAG, "openFileDescriptor unexpected error for $uri", error)
+            Pair(null, copyUriToTempFile(uri))
+        }
+    }
+
+    private fun copyUriToTempFile(uri: Uri): File? {
+        return try {
+            val inputStream = appContext.contentResolver.openInputStream(uri) ?: return null
+            inputStream.use { input ->
+                val tempFile = createVideoTempFile(appContext, "scoped_video_", ".tmp")
+                FileOutputStream(tempFile).use { output ->
+                    input.copyTo(output)
+                }
+                tempFile
+            }
+        } catch (error: Throwable) {
+            android.util.Log.w(TAG, "Failed to copy scoped URI $uri to temp file", error)
+            null
+        }
+    }
+
+    private fun DataSource.prepareLocalCopy(context: Context): PreparedUri {
+        return when (this) {
+            is DataSource.UriSource -> PreparedUri(uri)
+            is DataSource.PathSource -> PreparedUri(Uri.fromFile(File(path)))
+            is DataSource.DescriptorSource -> {
+                val dup = duplicate()
+                val temp = createVideoTempFile(context, "descriptor_copy_", ".tmp")
+                try {
+                    FileInputStream(dup.fileDescriptor).use { input ->
+                        FileOutputStream(temp).use { output ->
+                            input.channel.transferTo(0, Long.MAX_VALUE, output.channel)
+                        }
+                    }
+                } catch (error: Throwable) {
+                    if (!temp.delete()) {
+                        android.util.Log.d(TAG, "Temporary descriptor copy ${temp.absolutePath} could not be deleted after failure")
+                    }
+                    throw error
+                } finally {
+                    try {
+                        dup.close()
+                    } catch (_: Throwable) {
+                    }
+                }
+                PreparedUri(Uri.fromFile(temp)) {
+                    if (!temp.delete()) {
+                        android.util.Log.d(TAG, "Temporary descriptor copy ${temp.absolutePath} could not be deleted")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun sanitizeFrameTime(frameTimeUs: Long): Long {
+        return if (frameTimeUs <= 0L) DEFAULT_FALLBACK_FRAME_TIME_US else frameTimeUs
+    }
+
+    private fun maybeScale(bitmap: Bitmap, targetSizePx: Int): Bitmap {
+        if (targetSizePx <= 0) {
+            return bitmap
+        }
+        val maxDimension = max(bitmap.width, bitmap.height)
+        if (maxDimension <= targetSizePx) {
+            return bitmap
+        }
+        val scale = targetSizePx.toFloat() / maxDimension.toFloat()
+        val matrix = Matrix()
+        matrix.postScale(scale, scale)
+        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+    }
+
+    private fun imageToBitmap(image: Image): Bitmap {
+        val plane = image.planes.firstOrNull() ?: throw IOException("Image contains no planes")
+        val buffer = plane.buffer
+        buffer.rewind()
+        val pixelStride = plane.pixelStride
+        val rowStride = plane.rowStride
+        val rowPadding = rowStride - pixelStride * image.width
+        val bitmap = Bitmap.createBitmap(
+            image.width + rowPadding / pixelStride,
+            image.height,
+            Bitmap.Config.ARGB_8888,
+        )
+        bitmap.copyPixelsFromBuffer(buffer)
+        return Bitmap.createBitmap(bitmap, 0, 0, image.width, image.height)
+    }
+
+    private fun <T> runWithTimeout(timeoutMs: Long, block: () -> T): T {
+        val future: Future<T> = decodeExecutor.submit(Callable(block))
+        return try {
+            future.get(timeoutMs, TimeUnit.MILLISECONDS)
+        } catch (timeout: TimeoutException) {
+            future.cancel(true)
+            throw timeout
+        } catch (error: Exception) {
+            future.cancel(true)
+            throw error
+        }
+    }
+
+    private sealed class DataSource {
+        data class UriSource(val uri: Uri) : DataSource() {
+            override fun toString(): String = "UriSource(uri=$uri)"
+        }
+
+        data class PathSource(val path: String) : DataSource() {
+            override fun toString(): String = "PathSource(path=$path)"
+        }
+
+        data class DescriptorSource(private val descriptor: ParcelFileDescriptor) : DataSource() {
+            fun duplicate(): ParcelFileDescriptor {
+                return ParcelFileDescriptor.dup(descriptor.fileDescriptor)
+            }
+
+            override fun toString(): String = "DescriptorSource(descriptor=${descriptor.fd})"
+        }
+    }
+
+    private data class PreparedUri(val uri: Uri, val cleanup: (() -> Unit)? = null)
+
+    companion object {
+        private const val TAG = "VideoFrameExtractor"
+        private const val DEFAULT_TARGET_SIZE = 320
+        private const val DEFAULT_FALLBACK_FRAME_TIME_US = 1_000_000L
+        private const val DECODE_TIMEOUT_MS = 1_200L
+        private const val MAX_CONCURRENT_DECODE_JOBS = 2
+
+        private val threadId = AtomicInteger(0)
+
+        private val executor: ExecutorService by lazy {
+            Executors.newFixedThreadPool(MAX_CONCURRENT_DECODE_JOBS) { runnable ->
+                Thread(runnable, "VideoFrameDecode-${threadId.incrementAndGet()}").apply {
+                    priority = Thread.NORM_PRIORITY - 1
+                }
+            }
+        }
+
+        fun getInstance(context: Context): VideoFrameExtractor {
+            return VideoFrameExtractor(context.applicationContext)
+        }
+    }
+
+    private val decodeExecutor: ExecutorService
+        get() = executor
+}

--- a/android/app/src/main/kotlin/com/example/coalition_mobile_app/VideoNative.kt
+++ b/android/app/src/main/kotlin/com/example/coalition_mobile_app/VideoNative.kt
@@ -4,13 +4,11 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.media.Image
-import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Looper
-import android.os.ParcelFileDescriptor
+import android.provider.DocumentsContract
 import androidx.media3.common.Effect
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
@@ -57,6 +55,7 @@ class VideoNative(
     private val transformerHandler = Handler(transformerThread.looper)
     private var transformer: Transformer? = null
     private val isDisposed = AtomicBoolean(false)
+    private val frameExtractor = VideoFrameExtractor.getInstance(context)
 
     init {
         channel.setMethodCallHandler(this)
@@ -186,8 +185,9 @@ class VideoNative(
         executor.execute {
             try {
                 val uri = Uri.parse(uriString)
+                val intentFlags = call.argument<Int>("flags") ?: 0
                 if (uri.scheme.equals("content", ignoreCase = true)) {
-                    maybeTakePersistableUriPermission(uri)
+                    maybeTakePersistableUriPermission(uri, intentFlags)
                 }
                 postSuccess(result, null)
             } catch (t: Throwable) {
@@ -243,67 +243,33 @@ class VideoNative(
     }
 
     private fun generateCoverImage(filePath: String, seconds: Double): String {
-        val frameTimeUs = (seconds * 1_000_000L).toLong().coerceAtLeast(0L)
+        val frameTimeUs = (seconds * 1_000_000L).toLong()
         val parsedUri = try {
             Uri.parse(filePath)
         } catch (_: Throwable) {
             null
         }
-        val contentUri = parsedUri?.takeIf { it.scheme.equals("content", ignoreCase = true) }
 
-        var parcelFileDescriptor: ParcelFileDescriptor? = null
-        var copiedFile: File? = null
-
-        val retriever = MediaMetadataRetriever()
-        try {
-            if (contentUri != null) {
-                maybeTakePersistableUriPermission(contentUri)
-                parcelFileDescriptor = openContentFileDescriptor(contentUri)
-                if (parcelFileDescriptor != null) {
-                    retriever.setDataSource(parcelFileDescriptor!!.fileDescriptor)
-                } else {
-                    copiedFile = copyContentUriToTempFile(contentUri)
-                    val localCopy = copiedFile ?: throw IOException("Unable to open scoped URI: $contentUri")
-                    retriever.setDataSource(localCopy.absolutePath)
-                }
-            } else {
-                retriever.setDataSource(filePath)
+        val bitmap = when {
+            parsedUri != null && parsedUri.scheme.equals("content", ignoreCase = true) -> {
+                frameExtractor.extractFrameFromUri(parsedUri, frameTimeUs)
             }
-
-            val bitmap = retriever
-                .getFrameAtTime(frameTimeUs, MediaMetadataRetriever.OPTION_CLOSEST)
-                ?: throw IOException("Unable to retrieve frame with MediaMetadataRetriever")
-
-            return writeBitmapToCache(bitmap)
-        } catch (error: Throwable) {
-            android.util.Log.w(TAG, "MediaMetadataRetriever failed for $filePath", error)
-        } finally {
-            retriever.release()
-            try {
-                parcelFileDescriptor?.close()
-            } catch (_: Throwable) {
+            parsedUri != null && parsedUri.scheme.equals("file", ignoreCase = true) -> {
+                frameExtractor.extractFrameFromUri(parsedUri, frameTimeUs)
             }
-            copiedFile?.let {
-                if (!it.delete()) {
-                    android.util.Log.d(TAG, "Temporary copy ${it.absolutePath} could not be deleted immediately")
-                }
+            parsedUri != null && parsedUri.scheme.isNullOrEmpty().not() -> {
+                frameExtractor.extractFrameFromUri(parsedUri, frameTimeUs)
+            }
+            else -> {
+                frameExtractor.extractFrameFromPath(filePath, frameTimeUs)
             }
         }
 
-        val fallbackUri = contentUri ?: parsedUri ?: Uri.fromFile(File(filePath))
-        val fallbackBitmap = try {
-            extractFrameWithMedia3(fallbackUri, frameTimeUs)
-        } catch (error: Throwable) {
-            android.util.Log.e(TAG, "Media3 frame extraction failed for $fallbackUri", error)
-            null
-        }
-
-        val bitmap = fallbackBitmap ?: throw IOException("Unable to retrieve frame for $filePath")
         return writeBitmapToCache(bitmap)
     }
 
     private fun writeBitmapToCache(bitmap: Bitmap): String {
-        val outputFile = createTempFile(prefix = "cover_", suffix = ".png")
+        val outputFile = createVideoTempFile(context, prefix = "cover_", suffix = ".png")
         FileOutputStream(outputFile).use { output ->
             if (!bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
                 throw IOException("Failed to write cover image")
@@ -312,149 +278,23 @@ class VideoNative(
         return outputFile.absolutePath
     }
 
-    private fun maybeTakePersistableUriPermission(uri: Uri) {
+    private fun maybeTakePersistableUriPermission(uri: Uri, intentFlags: Int) {
+        if ((intentFlags and Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION) == 0) {
+            return
+        }
+        if (!DocumentsContract.isDocumentUri(context, uri)) {
+            return
+        }
+
         try {
             context.contentResolver.takePersistableUriPermission(
                 uri,
-                Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                intentFlags and (Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION),
             )
         } catch (security: SecurityException) {
             android.util.Log.w(TAG, "Unable to persist URI permission for $uri", security)
         } catch (_: Throwable) {
         }
-    }
-
-    private fun openContentFileDescriptor(uri: Uri): ParcelFileDescriptor? {
-        return try {
-            context.contentResolver.openFileDescriptor(uri, "r")
-        } catch (security: SecurityException) {
-            android.util.Log.w(TAG, "openFileDescriptor security exception for $uri", security)
-            null
-        } catch (ioe: IOException) {
-            android.util.Log.w(TAG, "openFileDescriptor IO exception for $uri", ioe)
-            null
-        } catch (t: Throwable) {
-            android.util.Log.w(TAG, "openFileDescriptor unexpected error for $uri", t)
-            null
-        }
-    }
-
-    private fun copyContentUriToTempFile(uri: Uri): File? {
-        return try {
-            val inputStream = context.contentResolver.openInputStream(uri) ?: return null
-            inputStream.use { input ->
-                val tempFile = createTempFile(prefix = "scoped_video_", suffix = ".tmp")
-                FileOutputStream(tempFile).use { output ->
-                    input.copyTo(output)
-                }
-                tempFile
-            }
-        } catch (t: Throwable) {
-            android.util.Log.w(TAG, "Failed to copy scoped URI $uri to temp file", t)
-            null
-        }
-    }
-
-    @OptIn(UnstableApi::class)
-    private fun extractFrameWithMedia3(uri: Uri, frameTimeUs: Long): Bitmap? {
-        val latch = CountDownLatch(1)
-        val result = AtomicReference<Bitmap?>()
-        val failure = AtomicReference<Throwable?>()
-        val finished = AtomicBoolean(false)
-
-        val transformer = FrameExtractionSupport.buildFrameExtractorTransformer(
-            context,
-            object : FrameExtractionSupport.Listener {
-                override fun onImageAvailable(image: Image) {
-                    try {
-                        result.set(imageToBitmap(image))
-                    } catch (t: Throwable) {
-                        failure.compareAndSet(null, t)
-                    } finally {
-                        if (finished.compareAndSet(false, true)) {
-                            latch.countDown()
-                        }
-                    }
-                }
-            },
-        )
-
-        transformer.addListener(
-            object : Transformer.Listener {
-                override fun onTransformationError(
-                    mediaItem: MediaItem,
-                    exception: Exception,
-                ) {
-                    failure.compareAndSet(null, exception)
-                    if (finished.compareAndSet(false, true)) {
-                        latch.countDown()
-                    }
-                }
-
-                override fun onTransformationCompleted(
-                    mediaItem: MediaItem,
-                    transformationResult: TransformationResult,
-                ) {
-                    if (result.get() == null) {
-                        failure.compareAndSet(null, IOException("No frame extracted"))
-                    }
-                    if (finished.compareAndSet(false, true)) {
-                        latch.countDown()
-                    }
-                }
-            },
-        )
-
-        val clipStartMs = max(0L, frameTimeUs / 1000)
-        val clipEndMs = clipStartMs + 1_000L
-
-        val mediaItemBuilder = MediaItem.Builder().setUri(uri)
-        mediaItemBuilder.setClippingConfiguration(
-            MediaItem.ClippingConfiguration.Builder()
-                .setStartPositionMs(clipStartMs)
-                .setEndPositionMs(clipEndMs)
-                .build(),
-        )
-
-        val edited = EditedMediaItem.Builder(mediaItemBuilder.build())
-            .setRemoveAudio(true)
-            .build()
-
-        val tempOutput = createTempFile(prefix = "frame_extract_", suffix = ".tmp")
-        try {
-            transformer.start(edited, tempOutput.absolutePath)
-            if (!latch.await(5, TimeUnit.SECONDS)) {
-                failure.compareAndSet(null, IOException("Timed out waiting for frame extraction"))
-                finished.compareAndSet(false, true)
-            }
-        } catch (ie: InterruptedException) {
-            Thread.currentThread().interrupt()
-            failure.compareAndSet(null, ie)
-        } finally {
-            transformer.cancel()
-            if (!tempOutput.delete()) {
-                android.util.Log.d(TAG, "Temporary transformer output ${tempOutput.absolutePath} could not be deleted")
-            }
-        }
-
-        failure.get()?.let { throw it }
-        return result.get()
-    }
-
-    private fun imageToBitmap(image: Image): Bitmap {
-        val plane = image.planes.firstOrNull() ?: throw IOException("Image contains no planes")
-        val buffer = plane.buffer
-        buffer.rewind()
-        val pixelStride = plane.pixelStride
-        val rowStride = plane.rowStride
-        val rowPadding = rowStride - pixelStride * image.width
-        val bitmap = Bitmap.createBitmap(
-            image.width + rowPadding / pixelStride,
-            image.height,
-            Bitmap.Config.ARGB_8888,
-        )
-        bitmap.copyPixelsFromBuffer(buffer)
-        return Bitmap.createBitmap(bitmap, 0, 0, image.width, image.height)
     }
 
     @OptIn(UnstableApi::class)
@@ -464,7 +304,7 @@ class VideoNative(
         targetBitrate: Int,
     ): String {
         val editedMediaItem = buildEditedMediaItem(filePath, timeline)
-        val outputFile = createTempFile(prefix = "export_", suffix = ".mp4")
+        val outputFile = createVideoTempFile(context, prefix = "export_", suffix = ".mp4")
 
         val latch = CountDownLatch(1)
         var exportError: Exception? = null
@@ -682,14 +522,6 @@ class VideoNative(
             bitmap.recycle()
             null
         }
-    }
-
-    private fun createTempFile(prefix: String, suffix: String): File {
-        val directory = File(context.cacheDir, "video_native")
-        if (!directory.exists()) {
-            directory.mkdirs()
-        }
-        return File.createTempFile(prefix, suffix, directory)
     }
 
     // Helpers to convert org.json types into Kotlin collections.

--- a/lib/features/video/platform/video_native.dart
+++ b/lib/features/video/platform/video_native.dart
@@ -8,7 +8,7 @@ abstract class VideoNativeBridge {
 
   Future<String> generateCoverImage(String filePath, {required double seconds});
 
-  Future<void> persistUriPermission(String uri);
+  Future<void> persistUriPermission(String uri, {int intentFlags = 0});
 
   Future<String> exportEdits({
     required String filePath,
@@ -39,9 +39,10 @@ class VideoNative implements VideoNativeBridge {
   }
 
   @override
-  Future<void> persistUriPermission(String uri) async {
+  Future<void> persistUriPermission(String uri, {int intentFlags = 0}) async {
     await _ch.invokeMethod<void>('persistUriPermission', {
       'uri': uri,
+      'flags': intentFlags,
     });
   }
 


### PR DESCRIPTION
## Summary
- add a dedicated VideoFrameExtractor with timeouts, multi-step fallbacks, and limited concurrency for thumbnail decoding
- intercept Glide video frame decoding to route requests through the shared extractor and prefer lightweight frames
- gate persistable URI permission calls behind intent flags and document URIs, and plumb the flag data from Dart

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd63f381e88328b8e775f657930ffe