### PR TITLE
Improve MediaMetadataRetriever frame request

### DIFF
--- a/android/app/src/main/kotlin/com/example/coalition_mobile_app/VideoFrameExtractor.kt
+++ b/android/app/src/main/kotlin/com/example/coalition_mobile_app/VideoFrameExtractor.kt
@@ -134,7 +134,7 @@ internal class VideoFrameExtractor private constructor(private val appContext: C
                     retriever.setDataSource(parcelFileDescriptor!!.fileDescriptor)
                 }
             }
-            retriever.getFrameAtTime(frameTimeUs, MediaMetadataRetriever.OPTION_CLOSEST)
+            retriever.requestSafeFrame(frameTimeUs)
         } catch (error: Throwable) {
             android.util.Log.w(TAG, "MediaMetadataRetriever threw for $dataSource", error)
             null
@@ -150,6 +150,16 @@ internal class VideoFrameExtractor private constructor(private val appContext: C
                 }
             }
         }
+    }
+
+    private fun MediaMetadataRetriever.requestSafeFrame(requestedFrameTimeUs: Long): Bitmap? {
+        val safeFrameTimeUs = if (requestedFrameTimeUs <= 0L) {
+            DEFAULT_FALLBACK_FRAME_TIME_US
+        } else {
+            requestedFrameTimeUs
+        }
+        return getFrameAtTime(safeFrameTimeUs, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
+            ?: getFrameAtTime(safeFrameTimeUs, MediaMetadataRetriever.OPTION_CLOSEST)
     }
 
     private fun attemptWithThumbnailUtils(dataSource: DataSource): Bitmap? {


### PR DESCRIPTION
## Summary
- request frames from MediaMetadataRetriever using a sync frame first to avoid null results
- fall back to OPTION_CLOSEST when a sync frame is unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd786569b88328b4ed950bb77f773d